### PR TITLE
Use clap for argument parsing

### DIFF
--- a/proxydetox/Cargo.toml
+++ b/proxydetox/Cargo.toml
@@ -15,7 +15,7 @@ libc = "0.2"
 inotify = "0.9"
 
 [dependencies]
-argh = "0.1"
+clap = "2.3"
 base64 = "0.13"
 dirs = "3.0"
 env_logger = "0.9"

--- a/proxydetox/src/main.rs
+++ b/proxydetox/src/main.rs
@@ -72,11 +72,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let auth = if config.negotiate {
         AuthenticatorFactory::negotiate()
     } else {
-        AuthenticatorFactory::basic()
+        AuthenticatorFactory::basic(config.netrc_file.clone())
     };
 
     #[cfg(not(feature = "negotiate"))]
-    let auth = AuthenticatorFactory::basic();
+    let auth = AuthenticatorFactory::basic(config.netrc_file.clone());
 
     tracing::info!("Authenticator factory: {}", &auth);
 
@@ -116,8 +116,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     #[cfg(target_os = "linux")]
     {
-        let mut netrc_path = dirs::home_dir().expect("home");
-        netrc_path.push(".netrc");
+        let netrc_path = config.netrc_file.clone();
         let tx = server.control_channel();
         tokio::spawn(async move {
             monitor_path(&netrc_path, tx).await;

--- a/proxydetox/src/options.rs
+++ b/proxydetox/src/options.rs
@@ -1,0 +1,151 @@
+use std::{
+    ffi::OsString,
+    fs::read_to_string,
+    path::{Path, PathBuf},
+    str::FromStr,
+    time::Duration,
+};
+
+use clap::{App, AppSettings, Arg, ArgMatches};
+
+#[derive(Debug)]
+pub struct Options {
+    #[cfg(feature = "negotiate")]
+    pub negotiate: bool,
+    pub pac_file: Option<String>,
+    pub always_use_connect: bool,
+    pub port: u16,
+    pub pool_max_idle_per_host: usize,
+    pub pool_idle_timeout: Option<Duration>,
+}
+
+fn is_num<T: FromStr + PartialOrd>(v: String) -> Result<(), String> {
+    match v.parse::<T>() {
+        Ok(_v) => Ok(()),
+        Err(ref _cause) => Err(format!("invalid number")),
+    }
+}
+
+fn is_file(v: String) -> Result<(), String> {
+    if Path::new(&v).is_file() {
+        Ok(())
+    } else {
+        Err(format!("file '{}' does not exists", &v))
+    }
+}
+
+impl Options {
+    pub fn load() -> Self {
+        let default_pool_max_idle_per_host = usize::MAX.to_string();
+        let app: _ = App::new(env!("CARGO_PKG_NAME"))
+            .version(env!("CARGO_PKG_VERSION"))
+            .about("A small proxy to relive the pain of some corporate proxies")
+            .setting(AppSettings::AllArgsOverrideSelf);
+
+        #[cfg(feature = "negotiate")]
+        let app = app.arg(
+            Arg::with_name("negotiate")
+                .short("n")
+                .long("negotiate")
+                .help("Enables Negotiate (SPNEGO) authentication"),
+        );
+
+        let app = app
+            .arg(
+                Arg::with_name("port")
+                    .short("P")
+                    .long("port")
+                    .help("Listening port")
+                    .validator(is_num::<u16>)
+                    .default_value("3128"),
+            )
+            .arg(
+                Arg::with_name("pac_file")
+                    .long("pac-file")
+                    .short("p")
+                    .help(
+                        "PAC file to be used to decide which upstream proxy to forward the request",
+                    )
+                    .validator(is_file)
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name("always_use_connect")
+                    .short("c")
+                    .long("always_use_connect")
+                    .help("Always use CONNECT method even for http:// resources"),
+            )
+            .arg(
+                Arg::with_name("pool_max_idle_per_host")
+                    .long("pool-max-idle-per-host")
+                    .help("Maximum idle connection per host allowed in the pool")
+                    .validator(is_num::<usize>)
+                    .default_value(&default_pool_max_idle_per_host),
+            )
+            .arg(
+                Arg::with_name("pool_idle_timeout")
+                    .long("pool-idle-timeout")
+                    .help("Optional timeout for idle sockets being kept-alive")
+                    .validator(is_num::<u64>)
+                    .takes_value(true),
+            );
+
+        let mut args = readrc();
+        args.extend(std::env::args_os());
+        let matches = app.get_matches_from(args);
+
+        matches.into()
+    }
+}
+
+impl From<ArgMatches<'_>> for Options {
+    fn from(m: ArgMatches) -> Self {
+        Self {
+            #[cfg(feature = "negotiate")]
+            negotiate: m.is_present("negotiate"),
+            pac_file: m.value_of("pac_file").map(|s| String::from(s)),
+            always_use_connect: m.is_present("always_use_connect"),
+            port: m
+                .value_of("port")
+                .map(|s| s.parse::<u16>().unwrap())
+                .unwrap(),
+            pool_max_idle_per_host: m
+                .value_of("pool_max_idle_per_host")
+                .map(|s| s.parse::<usize>().unwrap())
+                .unwrap(),
+            pool_idle_timeout: m
+                .value_of("pool_idle_timeout")
+                .map(|s| std::time::Duration::from_secs(s.parse::<u64>().unwrap())),
+        }
+    }
+}
+
+/// Load config file, but command line flags will override config file values.
+fn readrc() -> Vec<OsString> {
+    let user_config = dirs::config_dir()
+        .unwrap_or_else(|| "".into())
+        .join("proxydetox/proxydetoxrc");
+    let config_locations = vec![
+        user_config,
+        #[cfg(target_family = "unix")]
+        PathBuf::from("/etc/proxydetox/proxydetoxrc"),
+        #[cfg(target_family = "unix")]
+        PathBuf::from("/usr/local/etc/proxydetox/proxydetoxrc"),
+    ];
+    for path in config_locations {
+        if let Ok(content) = read_to_string(&path) {
+            // todo: this will fail with arguments which require a space (e.g. path of pac_file)
+            let args = content
+                .split('\n')
+                .map(|s| s.trim())
+                .filter(|s| !s.starts_with('#'))
+                .map(str::split_ascii_whitespace)
+                .flatten()
+                .filter(|s| !s.is_empty())
+                .map(|s| OsString::from(s))
+                .collect::<Vec<_>>();
+            return args;
+        }
+    }
+    Vec::new()
+}

--- a/proxydetox/src/options.rs
+++ b/proxydetox/src/options.rs
@@ -149,6 +149,10 @@ fn readrc() -> Vec<OsString> {
         PathBuf::from("/etc/proxydetox/proxydetoxrc"),
         #[cfg(target_family = "unix")]
         PathBuf::from("/usr/local/etc/proxydetox/proxydetoxrc"),
+        #[cfg(target_family = "windows")]
+        portable_dir("proxydetoxrc"),
+        #[cfg(target_family = "windows")]
+        portable_dir("proxydetoxrc.txt"),
     ];
     for path in config_locations {
         if let Ok(content) = read_to_string(&path) {
@@ -166,4 +170,21 @@ fn readrc() -> Vec<OsString> {
         }
     }
     Vec::new()
+}
+
+#[cfg(target_family = "windows")]
+// For Windows, use config file path next to the binary for portable use cases.
+pub fn portable_dir(path: impl AsRef<Path>) -> PathBuf {
+    let sys_config = std::env::current_exe()
+        .map(|p| {
+            p.parent()
+                .map(|p| {
+                    let mut p = PathBuf::from(p);
+                    p.push(path);
+                    p
+                })
+                .unwrap_or_default()
+        })
+        .unwrap_or_default();
+    sys_config
 }


### PR DESCRIPTION
This simplifies the usage of a rc file in combination with arguments by
leveraging AllArgsOverrideSelf