### PR TITLE
paclib: `Endpoint` instead of `Uri` for proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "paclib"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "duktape",
  "duktape-sys",

--- a/paclib/Cargo.toml
+++ b/paclib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paclib"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/paclib/src/evaluator.rs
+++ b/paclib/src/evaluator.rs
@@ -64,9 +64,9 @@ impl Evaluator {
         };
 
         match &result {
-            Ok(duktape::Value::String(ref result)) => {
-                Ok(Proxies::parse(result).map_err(|_| FindProxyError::InvalidResult)?)
-            }
+            Ok(duktape::Value::String(ref result)) => Ok(result
+                .parse::<Proxies>()
+                .map_err(|_| FindProxyError::InvalidResult)?),
             _ => Err(FindProxyError::InvalidResult),
         }
     }

--- a/paclib/src/lib.rs
+++ b/paclib/src/lib.rs
@@ -4,6 +4,7 @@ pub mod proxy;
 
 pub use crate::dns::DnsCache;
 pub use crate::evaluator::Evaluator;
+pub use crate::proxy::Endpoint;
 pub use crate::proxy::Proxies;
 pub use crate::proxy::ProxyDesc;
 

--- a/paclib/tests/pac_utils.rs
+++ b/paclib/tests/pac_utils.rs
@@ -1,8 +1,7 @@
-use paclib::{Evaluator, ProxyDesc};
+use paclib::{Endpoint, Evaluator, ProxyDesc, Uri};
 
 fn find_proxy(cmd: &str, good: &str, bad: &str) {
-    use paclib::Uri;
-    let proxy = "http://example.org:3128";
+    let endpoint = "example.org:3128".parse::<Endpoint>().unwrap();
     let pac_script = format!(
         r#"
         function FindProxyForURL(url, host) {{
@@ -12,9 +11,8 @@ fn find_proxy(cmd: &str, good: &str, bad: &str) {
             return "PROXY {}";
         }}
     "#,
-        cmd, proxy
+        cmd, endpoint
     );
-    let proxy = proxy.parse::<Uri>().unwrap();
     let mut eval = Evaluator::new(&pac_script).unwrap();
 
     assert_eq!(
@@ -24,7 +22,7 @@ fn find_proxy(cmd: &str, good: &str, bad: &str) {
             .first()
     );
     assert_eq!(
-        ProxyDesc::Proxy(proxy),
+        ProxyDesc::Proxy(endpoint),
         eval.find_proxy(&bad.parse::<Uri>().unwrap())
             .unwrap()
             .first()

--- a/proxy_client/src/http_proxy_connector.rs
+++ b/proxy_client/src/http_proxy_connector.rs
@@ -20,18 +20,17 @@ pub enum Error {
 
 #[derive(Clone, Debug)]
 pub struct HttpProxyConnector {
-    proxy_uri: Uri,
+    host: String,
+    port: u16,
 }
 
 impl HttpProxyConnector {
-    pub fn new(proxy_uri: Uri) -> Self {
-        Self { proxy_uri }
+    pub fn new((host, port): (String, u16)) -> Self {
+        Self { host, port }
     }
 
     async fn call_async(&mut self, _dst: Uri) -> std::result::Result<HttpProxyStream, Error> {
-        let port = self.proxy_uri.port_u16().unwrap_or(3128);
-        let host = self.proxy_uri.host().ok_or(Error::LookupError)?;
-        let stream = TcpStream::connect((host, port))
+        let stream = TcpStream::connect((self.host.clone(), self.port))
             .await
             .map_err(Error::ConnectError)?;
 

--- a/proxydetox/src/auth.rs
+++ b/proxydetox/src/auth.rs
@@ -40,8 +40,7 @@ impl AuthenticatorFactory {
         AuthenticatorFactory::Negotiate
     }
 
-    pub fn make(&self, proxy_url: &http::Uri) -> Result<Box<dyn Authenticator>> {
-        let proxy_fqdn = proxy_url.host().unwrap_or_default();
+    pub fn make(&self, proxy_fqdn: &str) -> Result<Box<dyn Authenticator>> {
         match self {
             Self::None => Ok(Box::new(NoneAuthenticator)),
             Self::Basic(ref store) => {


### PR DESCRIPTION
Only a `host:port` description is valid to describe a proxy in a PAC
file.