### PR TITLE
Select interface address to listen on

### DIFF
--- a/proxydetox/src/main.rs
+++ b/proxydetox/src/main.rs
@@ -110,7 +110,7 @@ async fn run(config: &Options) -> Result<(), proxydetox::Error> {
             .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "no socket found"))?;
         hyper::Server::from_tcp(listener)?
     } else {
-        let addr = SocketAddr::from(([127, 0, 0, 1], config.port));
+        let addr = SocketAddr::new(config.interface, config.port);
         hyper::Server::try_bind(&addr)?
     };
     let server = server.serve(session.clone());


### PR DESCRIPTION
Here is some work to be able to choose which interface the server will listen on, without using socket

Can be useful when running docker or VM on main machine and need to be able to communicate though proxy in container/VM.
-> Useful to create a docker container to run proxydetox as you can't use systemd

This is just an adaptation of #75 