### PR TITLE
Enable annex-b in Boa

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,13 +1,13 @@
 {
-  "checksum": "fcec1b773c82469f08436350e96a770c8ccc38f3d1d4271b6038ed17afdb64f2",
+  "checksum": "41adaee74f9a79c2292e2536242b80d5cc9825be50c579d7d8897b252c2fb3d6",
   "crates": {
-    "addr2line 0.20.0": {
+    "addr2line 0.21.0": {
       "name": "addr2line",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/addr2line/0.20.0/download",
-          "sha256": "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+          "url": "https://crates.io/api/v1/crates/addr2line/0.21.0/download",
+          "sha256": "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
         }
       },
       "targets": [
@@ -29,14 +29,14 @@
         "deps": {
           "common": [
             {
-              "id": "gimli 0.27.3",
+              "id": "gimli 0.28.0",
               "target": "gimli"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.20.0"
+        "version": "0.21.0"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -143,13 +143,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "aho-corasick 1.0.4": {
+    "aho-corasick 1.0.5": {
       "name": "aho-corasick",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/aho-corasick/1.0.4/download",
-          "sha256": "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+          "url": "https://crates.io/api/v1/crates/aho-corasick/1.0.5/download",
+          "sha256": "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
         }
       },
       "targets": [
@@ -179,14 +179,14 @@
         "deps": {
           "common": [
             {
-              "id": "memchr 2.5.0",
+              "id": "memchr 2.6.3",
               "target": "memchr"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.4"
+        "version": "1.0.5"
       },
       "license": "Unlicense OR MIT"
     },
@@ -259,13 +259,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "anstream 0.3.2": {
+    "anstream 0.5.0": {
       "name": "anstream",
-      "version": "0.3.2",
+      "version": "0.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anstream/0.3.2/download",
-          "sha256": "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+          "url": "https://crates.io/api/v1/crates/anstream/0.5.0/download",
+          "sha256": "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
         }
       },
       "targets": [
@@ -295,7 +295,7 @@
         "deps": {
           "common": [
             {
-              "id": "anstyle 1.0.1",
+              "id": "anstyle 1.0.2",
               "target": "anstyle"
             },
             {
@@ -311,10 +311,6 @@
               "target": "colorchoice"
             },
             {
-              "id": "is-terminal 0.4.9",
-              "target": "is_terminal"
-            },
-            {
               "id": "utf8parse 0.2.1",
               "target": "utf8parse"
             }
@@ -322,24 +318,24 @@
           "selects": {
             "cfg(windows)": [
               {
-                "id": "anstyle-wincon 1.0.2",
+                "id": "anstyle-wincon 2.1.0",
                 "target": "anstyle_wincon"
               }
             ]
           }
         },
         "edition": "2021",
-        "version": "0.3.2"
+        "version": "0.5.0"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "anstyle 1.0.1": {
+    "anstyle 1.0.2": {
       "name": "anstyle",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anstyle/1.0.1/download",
-          "sha256": "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+          "url": "https://crates.io/api/v1/crates/anstyle/1.0.2/download",
+          "sha256": "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
         }
       },
       "targets": [
@@ -366,7 +362,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.1"
+        "version": "1.0.2"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -457,13 +453,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "anstyle-wincon 1.0.2": {
+    "anstyle-wincon 2.1.0": {
       "name": "anstyle-wincon",
-      "version": "1.0.2",
+      "version": "2.1.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/anstyle-wincon/1.0.2/download",
-          "sha256": "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+          "url": "https://crates.io/api/v1/crates/anstyle-wincon/2.1.0/download",
+          "sha256": "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
         }
       },
       "targets": [
@@ -485,7 +481,7 @@
         "deps": {
           "common": [
             {
-              "id": "anstyle 1.0.1",
+              "id": "anstyle 1.0.2",
               "target": "anstyle"
             }
           ],
@@ -499,7 +495,7 @@
           }
         },
         "edition": "2021",
-        "version": "1.0.2"
+        "version": "2.1.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -650,13 +646,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "backtrace 0.3.68": {
+    "backtrace 0.3.69": {
       "name": "backtrace",
-      "version": "0.3.68",
+      "version": "0.3.69",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/backtrace/0.3.68/download",
-          "sha256": "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+          "url": "https://crates.io/api/v1/crates/backtrace/0.3.69/download",
+          "sha256": "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
         }
       },
       "targets": [
@@ -687,11 +683,7 @@
         "deps": {
           "common": [
             {
-              "id": "addr2line 0.20.0",
-              "target": "addr2line"
-            },
-            {
-              "id": "backtrace 0.3.68",
+              "id": "backtrace 0.3.69",
               "target": "build_script_build"
             },
             {
@@ -699,26 +691,33 @@
               "target": "cfg_if"
             },
             {
-              "id": "libc 0.2.147",
-              "target": "libc"
-            },
-            {
-              "id": "miniz_oxide 0.7.1",
-              "target": "miniz_oxide"
-            },
-            {
-              "id": "object 0.31.1",
-              "target": "object"
-            },
-            {
               "id": "rustc-demangle 0.1.23",
               "target": "rustc_demangle"
             }
           ],
-          "selects": {}
+          "selects": {
+            "cfg(not(all(windows, target_env = \"msvc\", not(target_vendor = \"uwp\"))))": [
+              {
+                "id": "addr2line 0.21.0",
+                "target": "addr2line"
+              },
+              {
+                "id": "libc 0.2.147",
+                "target": "libc"
+              },
+              {
+                "id": "miniz_oxide 0.7.1",
+                "target": "miniz_oxide"
+              },
+              {
+                "id": "object 0.32.1",
+                "target": "object"
+              }
+            ]
+          }
         },
         "edition": "2018",
-        "version": "0.3.68"
+        "version": "0.3.69"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -736,13 +735,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "base64 0.21.2": {
+    "base64 0.21.4": {
       "name": "base64",
-      "version": "0.21.2",
+      "version": "0.21.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/base64/0.21.2/download",
-          "sha256": "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+          "url": "https://crates.io/api/v1/crates/base64/0.21.4/download",
+          "sha256": "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
         }
       },
       "targets": [
@@ -768,8 +767,8 @@
           ],
           "selects": {}
         },
-        "edition": "2021",
-        "version": "0.21.2"
+        "edition": "2018",
+        "version": "0.21.4"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -861,7 +860,7 @@
               "target": "quote"
             },
             {
-              "id": "regex 1.9.3",
+              "id": "regex 1.9.5",
               "target": "regex"
             },
             {
@@ -869,7 +868,7 @@
               "target": "rustc_hash"
             },
             {
-              "id": "shlex 1.1.0",
+              "id": "shlex 1.2.0",
               "target": "shlex"
             },
             {
@@ -877,7 +876,7 @@
               "target": "syn"
             },
             {
-              "id": "which 4.4.0",
+              "id": "which 4.4.2",
               "target": "which"
             }
           ],
@@ -1005,7 +1004,7 @@
               "target": "indexmap"
             },
             {
-              "id": "num-bigint 0.4.3",
+              "id": "num-bigint 0.4.4",
               "target": "num_bigint"
             },
             {
@@ -1054,6 +1053,12 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "annex-b"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -1085,11 +1090,11 @@
               "target": "boa_profiler"
             },
             {
-              "id": "chrono 0.4.26",
+              "id": "chrono 0.4.30",
               "target": "chrono"
             },
             {
-              "id": "dashmap 5.5.1",
+              "id": "dashmap 5.5.3",
               "target": "dashmap"
             },
             {
@@ -1109,7 +1114,7 @@
               "target": "itertools"
             },
             {
-              "id": "num-bigint 0.4.3",
+              "id": "num-bigint 0.4.4",
               "target": "num_bigint"
             },
             {
@@ -1149,11 +1154,11 @@
               "target": "ryu_js"
             },
             {
-              "id": "serde 1.0.185",
+              "id": "serde 1.0.188",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.105",
+              "id": "serde_json 1.0.106",
               "target": "serde_json"
             },
             {
@@ -1173,7 +1178,7 @@
               "target": "thin_vec"
             },
             {
-              "id": "thiserror 1.0.47",
+              "id": "thiserror 1.0.48",
               "target": "thiserror"
             }
           ],
@@ -1429,7 +1434,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.29",
+              "id": "syn 2.0.32",
               "target": "syn"
             },
             {
@@ -1469,6 +1474,12 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "annex-b"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [
             {
@@ -1500,7 +1511,7 @@
               "target": "icu_properties"
             },
             {
-              "id": "num-bigint 0.4.3",
+              "id": "num-bigint 0.4.4",
               "target": "num_bigint"
             },
             {
@@ -1639,13 +1650,13 @@
       },
       "license": "Unlicense OR MIT"
     },
-    "bytes 1.4.0": {
+    "bytes 1.5.0": {
       "name": "bytes",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/bytes/1.4.0/download",
-          "sha256": "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+          "url": "https://crates.io/api/v1/crates/bytes/1.5.0/download",
+          "sha256": "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
         }
       },
       "targets": [
@@ -1672,7 +1683,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "1.4.0"
+        "version": "1.5.0"
       },
       "license": "MIT"
     },
@@ -1786,13 +1797,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "chrono 0.4.26": {
+    "chrono 0.4.30": {
       "name": "chrono",
-      "version": "0.4.26",
+      "version": "0.4.30",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/chrono/0.4.26/download",
-          "sha256": "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+          "url": "https://crates.io/api/v1/crates/chrono/0.4.30/download",
+          "sha256": "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
         }
       },
       "targets": [
@@ -1813,16 +1824,17 @@
         ],
         "crate_features": {
           "common": [
+            "android-tzdata",
             "clock",
             "default",
             "iana-time-zone",
             "js-sys",
             "oldtime",
             "std",
-            "time",
             "wasm-bindgen",
             "wasmbind",
-            "winapi"
+            "winapi",
+            "windows-targets"
           ],
           "selects": {}
         },
@@ -1831,10 +1843,6 @@
             {
               "id": "num-traits 0.2.16",
               "target": "num_traits"
-            },
-            {
-              "id": "time 0.1.45",
-              "target": "time"
             }
           ],
           "selects": {
@@ -1862,16 +1870,16 @@
             ],
             "cfg(windows)": [
               {
-                "id": "winapi 0.3.9",
-                "target": "winapi"
+                "id": "windows-targets 0.48.5",
+                "target": "windows_targets"
               }
             ]
           }
         },
         "edition": "2021",
-        "version": "0.4.26"
+        "version": "0.4.30"
       },
-      "license": "MIT/Apache-2.0"
+      "license": "MIT OR Apache-2.0"
     },
     "clang-sys 1.6.1": {
       "name": "clang-sys",
@@ -1963,13 +1971,13 @@
       },
       "license": "Apache-2.0"
     },
-    "clap 4.3.23": {
+    "clap 4.4.2": {
       "name": "clap",
-      "version": "4.3.23",
+      "version": "4.4.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap/4.3.23/download",
-          "sha256": "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
+          "url": "https://crates.io/api/v1/crates/clap/4.4.2/download",
+          "sha256": "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
         }
       },
       "targets": [
@@ -2005,12 +2013,8 @@
         "deps": {
           "common": [
             {
-              "id": "clap_builder 4.3.23",
+              "id": "clap_builder 4.4.2",
               "target": "clap_builder"
-            },
-            {
-              "id": "once_cell 1.18.0",
-              "target": "once_cell"
             }
           ],
           "selects": {}
@@ -2019,23 +2023,23 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "clap_derive 4.3.12",
+              "id": "clap_derive 4.4.2",
               "target": "clap_derive"
             }
           ],
           "selects": {}
         },
-        "version": "4.3.23"
+        "version": "4.4.2"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clap_builder 4.3.23": {
+    "clap_builder 4.4.2": {
       "name": "clap_builder",
-      "version": "4.3.23",
+      "version": "4.4.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap_builder/4.3.23/download",
-          "sha256": "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
+          "url": "https://crates.io/api/v1/crates/clap_builder/4.4.2/download",
+          "sha256": "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
         }
       },
       "targets": [
@@ -2069,15 +2073,15 @@
         "deps": {
           "common": [
             {
-              "id": "anstream 0.3.2",
+              "id": "anstream 0.5.0",
               "target": "anstream"
             },
             {
-              "id": "anstyle 1.0.1",
+              "id": "anstyle 1.0.2",
               "target": "anstyle"
             },
             {
-              "id": "clap_lex 0.5.0",
+              "id": "clap_lex 0.5.1",
               "target": "clap_lex"
             },
             {
@@ -2088,17 +2092,17 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "4.3.23"
+        "version": "4.4.2"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clap_derive 4.3.12": {
+    "clap_derive 4.4.2": {
       "name": "clap_derive",
-      "version": "4.3.12",
+      "version": "4.4.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap_derive/4.3.12/download",
-          "sha256": "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+          "url": "https://crates.io/api/v1/crates/clap_derive/4.4.2/download",
+          "sha256": "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
         }
       },
       "targets": [
@@ -2138,24 +2142,24 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.29",
+              "id": "syn 2.0.32",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "4.3.12"
+        "version": "4.4.2"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "clap_lex 0.5.0": {
+    "clap_lex 0.5.1": {
       "name": "clap_lex",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/clap_lex/0.5.0/download",
-          "sha256": "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+          "url": "https://crates.io/api/v1/crates/clap_lex/0.5.1/download",
+          "sha256": "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
         }
       },
       "targets": [
@@ -2175,7 +2179,7 @@
           "**"
         ],
         "edition": "2021",
-        "version": "0.5.0"
+        "version": "0.5.1"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -2312,13 +2316,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "dashmap 5.5.1": {
+    "dashmap 5.5.3": {
       "name": "dashmap",
-      "version": "5.5.1",
+      "version": "5.5.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/dashmap/5.5.1/download",
-          "sha256": "edd72493923899c6f10c641bdbdeddc7183d6396641d99c1a0d1597f37f92e28"
+          "url": "https://crates.io/api/v1/crates/dashmap/5.5.3/download",
+          "sha256": "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
         }
       },
       "targets": [
@@ -2363,7 +2367,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "5.5.1"
+        "version": "5.5.3"
       },
       "license": "MIT"
     },
@@ -2416,7 +2420,7 @@
                 "target": "netlink_packet_core"
               },
               {
-                "id": "netlink-packet-route 0.17.0",
+                "id": "netlink-packet-route 0.17.1",
                 "target": "netlink_packet_route"
               },
               {
@@ -2476,7 +2480,7 @@
               "target": "socket2"
             },
             {
-              "id": "thiserror 1.0.47",
+              "id": "thiserror 1.0.48",
               "target": "thiserror"
             },
             {
@@ -2624,7 +2628,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.29",
+              "id": "syn 2.0.32",
               "target": "syn"
             }
           ],
@@ -2753,7 +2757,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap 4.3.23",
+              "id": "clap 4.4.2",
               "target": "clap"
             },
             {
@@ -2789,7 +2793,7 @@
               "target": "log"
             },
             {
-              "id": "rustls 0.21.6",
+              "id": "rustls 0.21.7",
               "target": "rustls"
             },
             {
@@ -2797,7 +2801,7 @@
               "target": "rustls_native_certs"
             },
             {
-              "id": "thiserror 1.0.47",
+              "id": "thiserror 1.0.48",
               "target": "thiserror"
             },
             {
@@ -2903,7 +2907,7 @@
               "target": "log"
             },
             {
-              "id": "regex 1.9.3",
+              "id": "regex 1.9.5",
               "target": "regex"
             },
             {
@@ -2948,13 +2952,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "errno 0.3.2": {
+    "errno 0.3.3": {
       "name": "errno",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/errno/0.3.2/download",
-          "sha256": "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+          "url": "https://crates.io/api/v1/crates/errno/0.3.3/download",
+          "sha256": "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
         }
       },
       "targets": [
@@ -2973,6 +2977,12 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "std"
+          ],
+          "selects": {}
+        },
         "deps": {
           "common": [],
           "selects": {
@@ -3009,7 +3019,7 @@
           }
         },
         "edition": "2018",
-        "version": "0.3.2"
+        "version": "0.3.3"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3315,7 +3325,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.29",
+              "id": "syn 2.0.32",
               "target": "syn"
             }
           ],
@@ -3485,7 +3495,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "pin-project-lite 0.2.12",
+              "id": "pin-project-lite 0.2.13",
               "target": "pin_project_lite"
             },
             {
@@ -3673,13 +3683,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "gimli 0.27.3": {
+    "gimli 0.28.0": {
       "name": "gimli",
-      "version": "0.27.3",
+      "version": "0.28.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/gimli/0.27.3/download",
-          "sha256": "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+          "url": "https://crates.io/api/v1/crates/gimli/0.28.0/download",
+          "sha256": "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
         }
       },
       "targets": [
@@ -3699,7 +3709,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "0.27.3"
+        "version": "0.28.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -3761,7 +3771,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.4.0",
+              "id": "bytes 1.5.0",
               "target": "bytes"
             },
             {
@@ -3998,6 +4008,47 @@
       },
       "license": "MIT OR Apache-2.0"
     },
+    "home 0.5.5": {
+      "name": "home",
+      "version": "0.5.5",
+      "repository": {
+        "Http": {
+          "url": "https://crates.io/api/v1/crates/home/0.5.5/download",
+          "sha256": "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "home",
+            "crate_root": "src/lib.rs",
+            "srcs": [
+              "**/*.rs"
+            ]
+          }
+        }
+      ],
+      "library_target_name": "home",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [],
+          "selects": {
+            "cfg(windows)": [
+              {
+                "id": "windows-sys 0.48.0",
+                "target": "windows_sys"
+              }
+            ]
+          }
+        },
+        "edition": "2018",
+        "version": "0.5.5"
+      },
+      "license": "MIT OR Apache-2.0"
+    },
     "http 0.2.9": {
       "name": "http",
       "version": "0.2.9",
@@ -4026,7 +4077,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.4.0",
+              "id": "bytes 1.5.0",
               "target": "bytes"
             },
             {
@@ -4073,7 +4124,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.4.0",
+              "id": "bytes 1.5.0",
               "target": "bytes"
             },
             {
@@ -4081,7 +4132,7 @@
               "target": "http"
             },
             {
-              "id": "pin-project-lite 0.2.12",
+              "id": "pin-project-lite 0.2.13",
               "target": "pin_project_lite"
             }
           ],
@@ -4255,7 +4306,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.4.0",
+              "id": "bytes 1.5.0",
               "target": "bytes"
             },
             {
@@ -4295,7 +4346,7 @@
               "target": "itoa"
             },
             {
-              "id": "pin-project-lite 0.2.12",
+              "id": "pin-project-lite 0.2.13",
               "target": "pin_project_lite"
             },
             {
@@ -4384,7 +4435,7 @@
               "target": "log"
             },
             {
-              "id": "rustls 0.21.6",
+              "id": "rustls 0.21.7",
               "target": "rustls"
             },
             {
@@ -4832,7 +4883,7 @@
               "target": "icu_locid"
             },
             {
-              "id": "serde 1.0.185",
+              "id": "serde 1.0.188",
               "target": "serde"
             },
             {
@@ -5075,7 +5126,7 @@
           "selects": {
             "cfg(not(any(windows, target_os = \"hermit\", target_os = \"unknown\")))": [
               {
-                "id": "rustix 0.38.8",
+                "id": "rustix 0.38.13",
                 "target": "rustix"
               }
             ],
@@ -5362,7 +5413,7 @@
               "target": "bitflags"
             },
             {
-              "id": "bytes 1.4.0",
+              "id": "bytes 1.5.0",
               "target": "bytes"
             },
             {
@@ -5494,13 +5545,13 @@
       },
       "license": "ISC"
     },
-    "linux-raw-sys 0.4.5": {
+    "linux-raw-sys 0.4.7": {
       "name": "linux-raw-sys",
-      "version": "0.4.5",
+      "version": "0.4.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/linux-raw-sys/0.4.5/download",
-          "sha256": "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+          "url": "https://crates.io/api/v1/crates/linux-raw-sys/0.4.7/download",
+          "sha256": "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
         }
       },
       "targets": [
@@ -5521,6 +5572,7 @@
         ],
         "crate_features": {
           "common": [
+            "elf",
             "errno",
             "general",
             "ioctl",
@@ -5529,7 +5581,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.4.5"
+        "version": "0.4.7"
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
     },
@@ -5748,13 +5800,13 @@
       },
       "license": "MIT"
     },
-    "memchr 2.5.0": {
+    "memchr 2.6.3": {
       "name": "memchr",
-      "version": "2.5.0",
+      "version": "2.6.3",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/memchr/2.5.0/download",
-          "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+          "url": "https://crates.io/api/v1/crates/memchr/2.6.3/download",
+          "sha256": "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
         }
       },
       "targets": [
@@ -5762,15 +5814,6 @@
           "Library": {
             "crate_name": "memchr",
             "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        },
-        {
-          "BuildScript": {
-            "crate_name": "build_script_build",
-            "crate_root": "build.rs",
             "srcs": [
               "**/*.rs"
             ]
@@ -5784,29 +5827,16 @@
         ],
         "crate_features": {
           "common": [
+            "alloc",
             "default",
             "std"
           ],
           "selects": {}
         },
-        "deps": {
-          "common": [
-            {
-              "id": "memchr 2.5.0",
-              "target": "build_script_build"
-            }
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "2.5.0"
+        "edition": "2021",
+        "version": "2.6.3"
       },
-      "build_script_attrs": {
-        "data_glob": [
-          "**"
-        ]
-      },
-      "license": "Unlicense/MIT"
+      "license": "Unlicense OR MIT"
     },
     "minimal-lexical 0.2.1": {
       "name": "minimal-lexical",
@@ -5995,13 +6025,13 @@
       },
       "license": "MIT"
     },
-    "netlink-packet-route 0.17.0": {
+    "netlink-packet-route 0.17.1": {
       "name": "netlink-packet-route",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/netlink-packet-route/0.17.0/download",
-          "sha256": "f6de2fe935f44cbdfcab77dce2150d68eda75be715cd42d4d6f52b0bd4dcc5b1"
+          "url": "https://crates.io/api/v1/crates/netlink-packet-route/0.17.1/download",
+          "sha256": "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
         }
       },
       "targets": [
@@ -6050,7 +6080,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.17.0"
+        "version": "0.17.1"
       },
       "license": "MIT"
     },
@@ -6090,7 +6120,7 @@
               "target": "byteorder"
             },
             {
-              "id": "thiserror 1.0.47",
+              "id": "thiserror 1.0.48",
               "target": "thiserror"
             }
           ],
@@ -6144,7 +6174,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.4.0",
+              "id": "bytes 1.5.0",
               "target": "bytes"
             },
             {
@@ -6228,7 +6258,7 @@
         "deps": {
           "common": [
             {
-              "id": "memchr 2.5.0",
+              "id": "memchr 2.6.3",
               "target": "memchr"
             },
             {
@@ -6289,13 +6319,13 @@
       },
       "license": "MIT"
     },
-    "num-bigint 0.4.3": {
+    "num-bigint 0.4.4": {
       "name": "num-bigint",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/num-bigint/0.4.3/download",
-          "sha256": "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+          "url": "https://crates.io/api/v1/crates/num-bigint/0.4.4/download",
+          "sha256": "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
         }
       },
       "targets": [
@@ -6334,7 +6364,7 @@
         "deps": {
           "common": [
             {
-              "id": "num-bigint 0.4.3",
+              "id": "num-bigint 0.4.4",
               "target": "build_script_build"
             },
             {
@@ -6346,14 +6376,14 @@
               "target": "num_traits"
             },
             {
-              "id": "serde 1.0.185",
+              "id": "serde 1.0.188",
               "target": "serde"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.4.3"
+        "version": "0.4.4"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -6655,7 +6685,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.29",
+              "id": "syn 2.0.32",
               "target": "syn"
             }
           ],
@@ -6666,13 +6696,13 @@
       },
       "license": "BSD-3-Clause OR MIT OR Apache-2.0"
     },
-    "object 0.31.1": {
+    "object 0.32.1": {
       "name": "object",
-      "version": "0.31.1",
+      "version": "0.32.1",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/object/0.31.1/download",
-          "sha256": "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+          "url": "https://crates.io/api/v1/crates/object/0.32.1/download",
+          "sha256": "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
         }
       },
       "targets": [
@@ -6694,14 +6724,14 @@
         "deps": {
           "common": [
             {
-              "id": "memchr 2.5.0",
+              "id": "memchr 2.6.3",
               "target": "memchr"
             }
           ],
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.31.1"
+        "version": "0.32.1"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -6862,7 +6892,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap 4.3.23",
+              "id": "clap 4.4.2",
               "target": "clap"
             },
             {
@@ -6924,11 +6954,11 @@
               "target": "lazy_static"
             },
             {
-              "id": "regex 1.9.3",
+              "id": "regex 1.9.5",
               "target": "regex"
             },
             {
-              "id": "thiserror 1.0.47",
+              "id": "thiserror 1.0.48",
               "target": "thiserror"
             },
             {
@@ -7252,7 +7282,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.29",
+              "id": "syn 2.0.32",
               "target": "syn"
             }
           ],
@@ -7291,7 +7321,7 @@
         "deps": {
           "common": [
             {
-              "id": "siphasher 0.3.10",
+              "id": "siphasher 0.3.11",
               "target": "siphasher"
             }
           ],
@@ -7377,7 +7407,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.29",
+              "id": "syn 2.0.32",
               "target": "syn"
             }
           ],
@@ -7388,13 +7418,13 @@
       },
       "license": "Apache-2.0 OR MIT"
     },
-    "pin-project-lite 0.2.12": {
+    "pin-project-lite 0.2.13": {
       "name": "pin-project-lite",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/pin-project-lite/0.2.12/download",
-          "sha256": "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+          "url": "https://crates.io/api/v1/crates/pin-project-lite/0.2.13/download",
+          "sha256": "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
         }
       },
       "targets": [
@@ -7414,7 +7444,7 @@
           "**"
         ],
         "edition": "2018",
-        "version": "0.2.12"
+        "version": "0.2.13"
       },
       "license": "Apache-2.0 OR MIT"
     },
@@ -7547,7 +7577,7 @@
               "target": "once_cell"
             },
             {
-              "id": "toml_edit 0.19.14",
+              "id": "toml_edit 0.19.15",
               "target": "toml_edit"
             }
           ],
@@ -7657,11 +7687,11 @@
               "target": "hyper_rustls"
             },
             {
-              "id": "rustls 0.21.6",
+              "id": "rustls 0.21.7",
               "target": "rustls"
             },
             {
-              "id": "thiserror 1.0.47",
+              "id": "thiserror 1.0.48",
               "target": "thiserror"
             },
             {
@@ -7704,7 +7734,7 @@
         "deps": {
           "common": [
             {
-              "id": "clap 4.3.23",
+              "id": "clap 4.4.2",
               "target": "clap"
             },
             {
@@ -7728,7 +7758,7 @@
               "target": "lazy_static"
             },
             {
-              "id": "rustls 0.21.6",
+              "id": "rustls 0.21.7",
               "target": "rustls"
             },
             {
@@ -7802,15 +7832,15 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.21.2",
+              "id": "base64 0.21.4",
               "target": "base64"
             },
             {
-              "id": "bytes 1.4.0",
+              "id": "bytes 1.5.0",
               "target": "bytes"
             },
             {
-              "id": "chrono 0.4.26",
+              "id": "chrono 0.4.30",
               "target": "chrono"
             },
             {
@@ -7850,7 +7880,7 @@
               "target": "build_script_build"
             },
             {
-              "id": "rustls 0.21.6",
+              "id": "rustls 0.21.7",
               "target": "rustls"
             },
             {
@@ -7862,7 +7892,7 @@
               "target": "rustls_pemfile"
             },
             {
-              "id": "thiserror 1.0.47",
+              "id": "thiserror 1.0.48",
               "target": "thiserror"
             },
             {
@@ -8269,7 +8299,7 @@
               "target": "syscall"
             },
             {
-              "id": "thiserror 1.0.47",
+              "id": "thiserror 1.0.48",
               "target": "thiserror"
             }
           ],
@@ -8280,13 +8310,13 @@
       },
       "license": "MIT"
     },
-    "regex 1.9.3": {
+    "regex 1.9.5": {
       "name": "regex",
-      "version": "1.9.3",
+      "version": "1.9.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/regex/1.9.3/download",
-          "sha256": "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+          "url": "https://crates.io/api/v1/crates/regex/1.9.5/download",
+          "sha256": "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
         }
       },
       "targets": [
@@ -8330,26 +8360,26 @@
         "deps": {
           "common": [
             {
-              "id": "aho-corasick 1.0.4",
+              "id": "aho-corasick 1.0.5",
               "target": "aho_corasick"
             },
             {
-              "id": "memchr 2.5.0",
+              "id": "memchr 2.6.3",
               "target": "memchr"
             },
             {
-              "id": "regex-automata 0.3.6",
+              "id": "regex-automata 0.3.8",
               "target": "regex_automata"
             },
             {
-              "id": "regex-syntax 0.7.4",
+              "id": "regex-syntax 0.7.5",
               "target": "regex_syntax"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.9.3"
+        "version": "1.9.5"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -8400,13 +8430,13 @@
       },
       "license": "Unlicense/MIT"
     },
-    "regex-automata 0.3.6": {
+    "regex-automata 0.3.8": {
       "name": "regex-automata",
-      "version": "0.3.6",
+      "version": "0.3.8",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/regex-automata/0.3.6/download",
-          "sha256": "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+          "url": "https://crates.io/api/v1/crates/regex-automata/0.3.8/download",
+          "sha256": "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
         }
       },
       "targets": [
@@ -8455,22 +8485,22 @@
         "deps": {
           "common": [
             {
-              "id": "aho-corasick 1.0.4",
+              "id": "aho-corasick 1.0.5",
               "target": "aho_corasick"
             },
             {
-              "id": "memchr 2.5.0",
+              "id": "memchr 2.6.3",
               "target": "memchr"
             },
             {
-              "id": "regex-syntax 0.7.4",
+              "id": "regex-syntax 0.7.5",
               "target": "regex_syntax"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.3.6"
+        "version": "0.3.8"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -8518,13 +8548,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "regex-syntax 0.7.4": {
+    "regex-syntax 0.7.5": {
       "name": "regex-syntax",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/regex-syntax/0.7.4/download",
-          "sha256": "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+          "url": "https://crates.io/api/v1/crates/regex-syntax/0.7.5/download",
+          "sha256": "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
         }
       },
       "targets": [
@@ -8559,7 +8589,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.7.4"
+        "version": "0.7.5"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -8603,7 +8633,7 @@
               "target": "hashbrown"
             },
             {
-              "id": "memchr 2.5.0",
+              "id": "memchr 2.6.3",
               "target": "memchr"
             }
           ],
@@ -8792,13 +8822,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "rustix 0.38.8": {
+    "rustix 0.38.13": {
       "name": "rustix",
-      "version": "0.38.8",
+      "version": "0.38.13",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rustix/0.38.8/download",
-          "sha256": "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+          "url": "https://crates.io/api/v1/crates/rustix/0.38.13/download",
+          "sha256": "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
         }
       },
       "targets": [
@@ -8828,7 +8858,9 @@
         ],
         "crate_features": {
           "common": [
+            "alloc",
             "default",
+            "fs",
             "std",
             "termios",
             "use-libc-auxv"
@@ -8842,26 +8874,31 @@
               "target": "bitflags"
             },
             {
-              "id": "rustix 0.38.8",
+              "id": "rustix 0.38.13",
               "target": "build_script_build"
             }
           ],
           "selects": {
             "cfg(all(any(target_os = \"android\", target_os = \"linux\"), any(rustix_use_libc, miri, not(all(target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
               {
-                "id": "linux-raw-sys 0.4.5",
+                "id": "linux-raw-sys 0.4.7",
                 "target": "linux_raw_sys"
               }
             ],
             "cfg(all(not(rustix_use_libc), not(miri), target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\"))))": [
               {
-                "id": "linux-raw-sys 0.4.5",
+                "id": "errno 0.3.3",
+                "target": "errno",
+                "alias": "libc_errno"
+              },
+              {
+                "id": "linux-raw-sys 0.4.7",
                 "target": "linux_raw_sys"
               }
             ],
             "cfg(all(not(windows), any(rustix_use_libc, miri, not(all(target_os = \"linux\", target_endian = \"little\", any(target_arch = \"arm\", all(target_arch = \"aarch64\", target_pointer_width = \"64\"), target_arch = \"riscv64\", all(rustix_use_experimental_asm, target_arch = \"powerpc64\"), all(rustix_use_experimental_asm, target_arch = \"mips\"), all(rustix_use_experimental_asm, target_arch = \"mips32r6\"), all(rustix_use_experimental_asm, target_arch = \"mips64\"), all(rustix_use_experimental_asm, target_arch = \"mips64r6\"), target_arch = \"x86\", all(target_arch = \"x86_64\", target_pointer_width = \"64\")))))))": [
               {
-                "id": "errno 0.3.2",
+                "id": "errno 0.3.3",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -8872,7 +8909,7 @@
             ],
             "cfg(windows)": [
               {
-                "id": "errno 0.3.2",
+                "id": "errno 0.3.3",
                 "target": "errno",
                 "alias": "libc_errno"
               },
@@ -8884,7 +8921,7 @@
           }
         },
         "edition": "2021",
-        "version": "0.38.8"
+        "version": "0.38.13"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -8893,13 +8930,13 @@
       },
       "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
     },
-    "rustls 0.21.6": {
+    "rustls 0.21.7": {
       "name": "rustls",
-      "version": "0.21.6",
+      "version": "0.21.7",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/rustls/0.21.6/download",
-          "sha256": "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+          "url": "https://crates.io/api/v1/crates/rustls/0.21.7/download",
+          "sha256": "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
         }
       },
       "targets": [
@@ -8947,7 +8984,7 @@
               "target": "ring"
             },
             {
-              "id": "rustls 0.21.6",
+              "id": "rustls 0.21.7",
               "target": "build_script_build"
             },
             {
@@ -8962,7 +8999,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.21.6"
+        "version": "0.21.7"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -9057,7 +9094,7 @@
         "deps": {
           "common": [
             {
-              "id": "base64 0.21.2",
+              "id": "base64 0.21.4",
               "target": "base64"
             }
           ],
@@ -9402,13 +9439,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde 1.0.185": {
+    "serde 1.0.188": {
       "name": "serde",
-      "version": "1.0.185",
+      "version": "1.0.188",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde/1.0.185/download",
-          "sha256": "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+          "url": "https://crates.io/api/v1/crates/serde/1.0.188/download",
+          "sha256": "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
         }
       },
       "targets": [
@@ -9450,7 +9487,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.185",
+              "id": "serde 1.0.188",
               "target": "build_script_build"
             }
           ],
@@ -9460,13 +9497,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "serde_derive 1.0.185",
+              "id": "serde_derive 1.0.188",
               "target": "serde_derive"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.185"
+        "version": "1.0.188"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -9475,13 +9512,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_derive 1.0.185": {
+    "serde_derive 1.0.188": {
       "name": "serde_derive",
-      "version": "1.0.185",
+      "version": "1.0.188",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.185/download",
-          "sha256": "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
+          "url": "https://crates.io/api/v1/crates/serde_derive/1.0.188/download",
+          "sha256": "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
         }
       },
       "targets": [
@@ -9517,24 +9554,24 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.29",
+              "id": "syn 2.0.32",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.0.185"
+        "version": "1.0.188"
       },
       "license": "MIT OR Apache-2.0"
     },
-    "serde_json 1.0.105": {
+    "serde_json 1.0.106": {
       "name": "serde_json",
-      "version": "1.0.105",
+      "version": "1.0.106",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/serde_json/1.0.105/download",
-          "sha256": "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+          "url": "https://crates.io/api/v1/crates/serde_json/1.0.106/download",
+          "sha256": "2cc66a619ed80bf7a0f6b17dd063a84b88f6dea1813737cf469aef1d081142c2"
         }
       },
       "targets": [
@@ -9580,18 +9617,18 @@
               "target": "ryu"
             },
             {
-              "id": "serde 1.0.185",
+              "id": "serde 1.0.188",
               "target": "serde"
             },
             {
-              "id": "serde_json 1.0.105",
+              "id": "serde_json 1.0.106",
               "target": "build_script_build"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.105"
+        "version": "1.0.106"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -9639,13 +9676,13 @@
       },
       "license": "MIT"
     },
-    "shlex 1.1.0": {
+    "shlex 1.2.0": {
       "name": "shlex",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/shlex/1.1.0/download",
-          "sha256": "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+          "url": "https://crates.io/api/v1/crates/shlex/1.2.0/download",
+          "sha256": "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
         }
       },
       "targets": [
@@ -9672,7 +9709,7 @@
           "selects": {}
         },
         "edition": "2015",
-        "version": "1.1.0"
+        "version": "1.2.0"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -9715,13 +9752,13 @@
       },
       "license": "Apache-2.0/MIT"
     },
-    "siphasher 0.3.10": {
+    "siphasher 0.3.11": {
       "name": "siphasher",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/siphasher/0.3.10/download",
-          "sha256": "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+          "url": "https://crates.io/api/v1/crates/siphasher/0.3.11/download",
+          "sha256": "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
         }
       },
       "targets": [
@@ -9748,7 +9785,7 @@
           "selects": {}
         },
         "edition": "2018",
-        "version": "0.3.10"
+        "version": "0.3.11"
       },
       "license": "MIT/Apache-2.0"
     },
@@ -10243,13 +10280,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "syn 2.0.29": {
+    "syn 2.0.32": {
       "name": "syn",
-      "version": "2.0.29",
+      "version": "2.0.32",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/syn/2.0.29/download",
-          "sha256": "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+          "url": "https://crates.io/api/v1/crates/syn/2.0.32/download",
+          "sha256": "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
         }
       },
       "targets": [
@@ -10302,7 +10339,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "2.0.29"
+        "version": "2.0.32"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -10407,7 +10444,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.29",
+              "id": "syn 2.0.32",
               "target": "syn"
             },
             {
@@ -10637,13 +10674,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "thiserror 1.0.47": {
+    "thiserror 1.0.48": {
       "name": "thiserror",
-      "version": "1.0.47",
+      "version": "1.0.48",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/thiserror/1.0.47/download",
-          "sha256": "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+          "url": "https://crates.io/api/v1/crates/thiserror/1.0.48/download",
+          "sha256": "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
         }
       },
       "targets": [
@@ -10674,7 +10711,7 @@
         "deps": {
           "common": [
             {
-              "id": "thiserror 1.0.47",
+              "id": "thiserror 1.0.48",
               "target": "build_script_build"
             }
           ],
@@ -10684,13 +10721,13 @@
         "proc_macro_deps": {
           "common": [
             {
-              "id": "thiserror-impl 1.0.47",
+              "id": "thiserror-impl 1.0.48",
               "target": "thiserror_impl"
             }
           ],
           "selects": {}
         },
-        "version": "1.0.47"
+        "version": "1.0.48"
       },
       "build_script_attrs": {
         "data_glob": [
@@ -10699,13 +10736,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "thiserror-impl 1.0.47": {
+    "thiserror-impl 1.0.48": {
       "name": "thiserror-impl",
-      "version": "1.0.47",
+      "version": "1.0.48",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/thiserror-impl/1.0.47/download",
-          "sha256": "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+          "url": "https://crates.io/api/v1/crates/thiserror-impl/1.0.48/download",
+          "sha256": "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
         }
       },
       "targets": [
@@ -10735,14 +10772,14 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.29",
+              "id": "syn 2.0.32",
               "target": "syn"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "1.0.47"
+        "version": "1.0.48"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -10788,58 +10825,6 @@
         "version": "1.1.7"
       },
       "license": "MIT OR Apache-2.0"
-    },
-    "time 0.1.45": {
-      "name": "time",
-      "version": "0.1.45",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/time/0.1.45/download",
-          "sha256": "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "time",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "time",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "deps": {
-          "common": [
-            {
-              "id": "libc 0.2.147",
-              "target": "libc"
-            }
-          ],
-          "selects": {
-            "cfg(target_os = \"wasi\")": [
-              {
-                "id": "wasi 0.10.0+wasi-snapshot-preview1",
-                "target": "wasi"
-              }
-            ],
-            "cfg(windows)": [
-              {
-                "id": "winapi 0.3.9",
-                "target": "winapi"
-              }
-            ]
-          }
-        },
-        "edition": "2015",
-        "version": "0.1.45"
-      },
-      "license": "MIT/Apache-2.0"
     },
     "tinystr 0.7.1": {
       "name": "tinystr",
@@ -10946,7 +10931,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.4.0",
+              "id": "bytes 1.5.0",
               "target": "bytes"
             },
             {
@@ -10958,7 +10943,7 @@
               "target": "num_cpus"
             },
             {
-              "id": "pin-project-lite 0.2.12",
+              "id": "pin-project-lite 0.2.13",
               "target": "pin_project_lite"
             }
           ],
@@ -10971,7 +10956,7 @@
             ],
             "cfg(tokio_taskdump)": [
               {
-                "id": "backtrace 0.3.68",
+                "id": "backtrace 0.3.69",
                 "target": "backtrace"
               }
             ],
@@ -11043,7 +11028,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.29",
+              "id": "syn 2.0.32",
               "target": "syn"
             }
           ],
@@ -11090,7 +11075,7 @@
         "deps": {
           "common": [
             {
-              "id": "rustls 0.21.6",
+              "id": "rustls 0.21.7",
               "target": "rustls"
             },
             {
@@ -11146,7 +11131,7 @@
               "target": "futures_core"
             },
             {
-              "id": "pin-project-lite 0.2.12",
+              "id": "pin-project-lite 0.2.13",
               "target": "pin_project_lite"
             },
             {
@@ -11201,7 +11186,7 @@
         "deps": {
           "common": [
             {
-              "id": "bytes 1.4.0",
+              "id": "bytes 1.5.0",
               "target": "bytes"
             },
             {
@@ -11213,7 +11198,7 @@
               "target": "futures_sink"
             },
             {
-              "id": "pin-project-lite 0.2.12",
+              "id": "pin-project-lite 0.2.13",
               "target": "pin_project_lite"
             },
             {
@@ -11262,13 +11247,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "toml_edit 0.19.14": {
+    "toml_edit 0.19.15": {
       "name": "toml_edit",
-      "version": "0.19.14",
+      "version": "0.19.15",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/toml_edit/0.19.14/download",
-          "sha256": "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+          "url": "https://crates.io/api/v1/crates/toml_edit/0.19.15/download",
+          "sha256": "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
         }
       },
       "targets": [
@@ -11304,14 +11289,14 @@
               "target": "toml_datetime"
             },
             {
-              "id": "winnow 0.5.14",
+              "id": "winnow 0.5.15",
               "target": "winnow"
             }
           ],
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.19.14"
+        "version": "0.19.15"
       },
       "license": "MIT OR Apache-2.0"
     },
@@ -11369,7 +11354,7 @@
               "target": "pin_project"
             },
             {
-              "id": "pin-project-lite 0.2.12",
+              "id": "pin-project-lite 0.2.13",
               "target": "pin_project_lite"
             },
             {
@@ -11498,7 +11483,7 @@
               "target": "log"
             },
             {
-              "id": "pin-project-lite 0.2.12",
+              "id": "pin-project-lite 0.2.13",
               "target": "pin_project_lite"
             },
             {
@@ -11558,7 +11543,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.29",
+              "id": "syn 2.0.32",
               "target": "syn"
             }
           ],
@@ -11791,7 +11776,7 @@
               "target": "once_cell"
             },
             {
-              "id": "regex 1.9.3",
+              "id": "regex 1.9.5",
               "target": "regex"
             },
             {
@@ -12170,43 +12155,6 @@
       },
       "license": "MIT"
     },
-    "wasi 0.10.0+wasi-snapshot-preview1": {
-      "name": "wasi",
-      "version": "0.10.0+wasi-snapshot-preview1",
-      "repository": {
-        "Http": {
-          "url": "https://crates.io/api/v1/crates/wasi/0.10.0+wasi-snapshot-preview1/download",
-          "sha256": "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-        }
-      },
-      "targets": [
-        {
-          "Library": {
-            "crate_name": "wasi",
-            "crate_root": "src/lib.rs",
-            "srcs": [
-              "**/*.rs"
-            ]
-          }
-        }
-      ],
-      "library_target_name": "wasi",
-      "common_attrs": {
-        "compile_data_glob": [
-          "**"
-        ],
-        "crate_features": {
-          "common": [
-            "default",
-            "std"
-          ],
-          "selects": {}
-        },
-        "edition": "2018",
-        "version": "0.10.0+wasi-snapshot-preview1"
-      },
-      "license": "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
-    },
     "wasi 0.11.0+wasi-snapshot-preview1": {
       "name": "wasi",
       "version": "0.11.0+wasi-snapshot-preview1",
@@ -12372,7 +12320,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.29",
+              "id": "syn 2.0.32",
               "target": "syn"
             },
             {
@@ -12478,7 +12426,7 @@
               "target": "quote"
             },
             {
-              "id": "syn 2.0.29",
+              "id": "syn 2.0.32",
               "target": "syn"
             },
             {
@@ -12602,13 +12550,13 @@
       },
       "license": "MIT/Apache-2.0"
     },
-    "which 4.4.0": {
+    "which 4.4.2": {
       "name": "which",
-      "version": "4.4.0",
+      "version": "4.4.2",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/which/4.4.0/download",
-          "sha256": "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+          "url": "https://crates.io/api/v1/crates/which/4.4.2/download",
+          "sha256": "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
         }
       },
       "targets": [
@@ -12634,11 +12582,17 @@
               "target": "either"
             },
             {
-              "id": "libc 0.2.147",
-              "target": "libc"
+              "id": "rustix 0.38.13",
+              "target": "rustix"
             }
           ],
           "selects": {
+            "cfg(any(windows, unix, target_os = \"redox\"))": [
+              {
+                "id": "home 0.5.5",
+                "target": "home"
+              }
+            ],
             "cfg(windows)": [
               {
                 "id": "once_cell 1.18.0",
@@ -12647,8 +12601,8 @@
             ]
           }
         },
-        "edition": "2018",
-        "version": "4.4.0"
+        "edition": "2021",
+        "version": "4.4.2"
       },
       "license": "MIT"
     },
@@ -12695,16 +12649,11 @@
             "fileapi",
             "handleapi",
             "libloaderapi",
-            "minwinbase",
             "minwindef",
-            "ntdef",
             "ntsecapi",
             "processenv",
             "processthreadsapi",
-            "profileapi",
             "std",
-            "sysinfoapi",
-            "timezoneapi",
             "winbase",
             "wincon",
             "winerror",
@@ -13567,13 +13516,13 @@
       },
       "license": "MIT OR Apache-2.0"
     },
-    "winnow 0.5.14": {
+    "winnow 0.5.15": {
       "name": "winnow",
-      "version": "0.5.14",
+      "version": "0.5.15",
       "repository": {
         "Http": {
-          "url": "https://crates.io/api/v1/crates/winnow/0.5.14/download",
-          "sha256": "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
+          "url": "https://crates.io/api/v1/crates/winnow/0.5.15/download",
+          "sha256": "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
         }
       },
       "targets": [
@@ -13601,7 +13550,7 @@
           "selects": {}
         },
         "edition": "2021",
-        "version": "0.5.14"
+        "version": "0.5.15"
       },
       "license": "MIT"
     },
@@ -13709,7 +13658,7 @@
         "deps": {
           "common": [
             {
-              "id": "serde 1.0.185",
+              "id": "serde 1.0.188",
               "target": "serde"
             },
             {
@@ -14137,6 +14086,32 @@
       "x86_64-apple-darwin",
       "x86_64-apple-ios"
     ],
+    "cfg(any(windows, unix, target_os = \"redox\"))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-fuchsia",
+      "aarch64-linux-android",
+      "aarch64-pc-windows-msvc",
+      "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-pc-windows-msvc",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-fuchsia",
+      "x86_64-linux-android",
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu"
+    ],
     "cfg(not(all(target_arch = \"arm\", target_os = \"none\")))": [
       "aarch64-apple-darwin",
       "aarch64-apple-ios",
@@ -14166,6 +14141,36 @@
       "x86_64-fuchsia",
       "x86_64-linux-android",
       "x86_64-pc-windows-msvc",
+      "x86_64-unknown-freebsd",
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-none"
+    ],
+    "cfg(not(all(windows, target_env = \"msvc\", not(target_vendor = \"uwp\"))))": [
+      "aarch64-apple-darwin",
+      "aarch64-apple-ios",
+      "aarch64-apple-ios-sim",
+      "aarch64-fuchsia",
+      "aarch64-linux-android",
+      "aarch64-unknown-linux-gnu",
+      "arm-unknown-linux-gnueabi",
+      "armv7-linux-androideabi",
+      "armv7-unknown-linux-gnueabi",
+      "i686-apple-darwin",
+      "i686-linux-android",
+      "i686-unknown-freebsd",
+      "i686-unknown-linux-gnu",
+      "powerpc-unknown-linux-gnu",
+      "riscv32imc-unknown-none-elf",
+      "riscv64gc-unknown-none-elf",
+      "s390x-unknown-linux-gnu",
+      "thumbv7em-none-eabi",
+      "thumbv8m.main-none-eabi",
+      "wasm32-unknown-unknown",
+      "wasm32-wasi",
+      "x86_64-apple-darwin",
+      "x86_64-apple-ios",
+      "x86_64-fuchsia",
+      "x86_64-linux-android",
       "x86_64-unknown-freebsd",
       "x86_64-unknown-linux-gnu",
       "x86_64-unknown-none"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
 ]
@@ -54,24 +54,23 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
 
 [[package]]
 name = "anstyle-parse"
@@ -93,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -124,9 +123,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
@@ -139,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "bindgen"
@@ -279,7 +278,7 @@ checksum = "ca3de43b7806061fccfba716fef51eea462d636de36803b62d10f902608ffef4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
  "synstructure 0.13.0",
 ]
 
@@ -324,9 +323,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
@@ -354,17 +353,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "time",
  "wasm-bindgen",
- "winapi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -380,20 +378,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.23"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
+checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.23"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
 dependencies = [
  "anstream",
  "anstyle",
@@ -403,21 +400,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "colorchoice"
@@ -449,9 +446,9 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "dashmap"
-version = "5.5.1"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd72493923899c6f10c641bdbdeddc7183d6396641d99c1a0d1597f37f92e28"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
  "hashbrown 0.14.0",
@@ -516,7 +513,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -589,9 +586,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -643,7 +640,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -701,14 +698,14 @@ checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
 name = "glob"
@@ -767,6 +764,15 @@ name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "http"
@@ -1057,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "litemap"
@@ -1100,9 +1106,9 @@ checksum = "df39d232f5c40b0891c10216992c2f250c054105cb1e56f0fc9032db6203ecc1"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "minimal-lexical"
@@ -1126,7 +1132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -1143,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6de2fe935f44cbdfcab77dce2150d68eda75be715cd42d4d6f52b0bd4dcc5b1"
+checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -1206,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1263,14 +1269,14 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -1384,7 +1390,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1413,14 +1419,14 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1605,14 +1611,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.6",
- "regex-syntax 0.7.4",
+ "regex-automata 0.3.8",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -1626,13 +1632,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -1643,9 +1649,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regress"
@@ -1686,9 +1692,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -1699,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
@@ -1802,29 +1808,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.185"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.185"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "2cc66a619ed80bf7a0f6b17dd063a84b88f6dea1813737cf469aef1d081142c2"
 dependencies = [
  "itoa",
  "ryu",
@@ -1842,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1857,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -1947,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1976,7 +1982,7 @@ checksum = "285ba80e733fac80aa4270fbcdf83772a79b80aa35c97075320abfee4a915b06"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
  "unicode-xid",
 ]
 
@@ -2024,22 +2030,22 @@ checksum = "aac81b6fd6beb5884b0cf3321b8117e6e5d47ecb6fc89f414cfdcca8b2fe2dd8"
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2050,17 +2056,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -2099,7 +2094,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2146,9 +2141,9 @@ checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.0.0",
  "toml_datetime",
@@ -2203,7 +2198,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2320,12 +2315,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -2351,7 +2340,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
  "wasm-bindgen-shared",
 ]
 
@@ -2373,7 +2362,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2396,13 +2385,14 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
  "either",
- "libc",
+ "home",
  "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -2532,9 +2522,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
+checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
  "memchr",
 ]

--- a/paclib/Cargo.toml
+++ b/paclib/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-boa_engine = "0.17"
+boa_engine = { version = "0.17", features = ["annex-b"] }
 boa_gc = "0.17"
 default-net = { version = "0.17" }
 detox_net = { path = "../detox_net" }


### PR DESCRIPTION
Some PAC scripts use `host.substr()` which would be unavailable otherwise.

Closes #311 