### PR TITLE
windows: Add `--attach-console` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,6 +1545,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "windows 0.58.0",
 ]
 
 [[package]]

--- a/doc/BUILD
+++ b/doc/BUILD
@@ -22,6 +22,7 @@ mdbook(
         "service.md",
         "transparent_proxy.md",
         "usage.md",
+        "windows.md",
         ":proxydetox_help",
     ],
     book = "//:book.toml",

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Installation](installation.md)
 - [Configuration](configuration.md)
 - [Usage](usage.md)
+  - [Windows users](windows.md)
 
 ---
 

--- a/doc/windows.md
+++ b/doc/windows.md
@@ -1,0 +1,11 @@
+# Windows
+
+On Windows Proxydetox is _not_ a console application and therefor no console window is visible.
+No console window is shown, such that Proxydetox can be launched as a background process without any disturbing windows.
+
+The missing console windows also has the effect, that when Proxydetox is launched from the terminal no output is visible.
+The help output as well as the log output is affected by this. An online version of the help output can be found in the
+[command line reference](cliref.md) section.
+
+Additionally there is the `--attach-console` options on Windows builds of Proxydetox to attach to the parrent console.
+When running Proxydetox from the Windows command prompt, add the `--attach-console` optin to be able to see the output.

--- a/proxydetox/Cargo.toml
+++ b/proxydetox/Cargo.toml
@@ -31,3 +31,9 @@ tracing-subscriber.workspace = true
 tokio-rustls.workspace = true
 rustls-pemfile.workspace = true
 rustls.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.58", features = [
+    "Win32_System",
+    "Win32_System_Console",
+] }

--- a/proxydetox/src/main.rs
+++ b/proxydetox/src/main.rs
@@ -35,6 +35,16 @@ pub extern "C" fn main() {
 fn main() {
     let config = Options::load();
 
+    #[cfg(target_family = "windows")]
+    if config.attach_console {
+        unsafe {
+            windows::Win32::System::Console::AttachConsole(
+                windows::Win32::System::Console::ATTACH_PARENT_PROCESS,
+            )
+            .unwrap();
+        }
+    }
+
     if let Err(error) = run(config) {
         tracing::error!(%error, "fatal error");
         write_error(&mut std::io::stderr(), error).ok();

--- a/proxydetox/src/options.rs
+++ b/proxydetox/src/options.rs
@@ -26,6 +26,8 @@ pub enum Authorization {
 
 #[derive(Debug)]
 pub struct Options {
+    #[cfg(target_family = "windows")]
+    pub attach_console: bool,
     pub log_level: LevelFilter,
     pub log_filepath: Option<PathBuf>,
     pub pac_file: Option<PathOrUri>,
@@ -112,6 +114,14 @@ impl Options {
             .version(*proxydetoxlib::VERSION_STR)
             .about("A small proxy to relieve the pain of some corporate proxies")
             .args_override_self(true);
+
+        #[cfg(target_family = "windows")]
+        let app = app.arg(
+            Arg::new("attach_console")
+                .long("attach-console")
+                .help("Attache to the console of the parent process")
+                .action(ArgAction::SetTrue),
+        );
 
         #[cfg(feature = "negotiate")]
         let app = app.arg(
@@ -354,6 +364,8 @@ impl From<ArgMatches> for Options {
             .with_retries(m.get_one::<u32>("server_tcp_keepalive_retries").cloned());
 
         Self {
+            #[cfg(target_family = "windows")]
+            attach_console: m.get_flag("attach_console"),
             log_level,
             log_filepath: m.get_one("log_filepath").cloned(),
             pac_file: m


### PR DESCRIPTION
Allow Windows users as in #411 to show the console output of Proxydetox.