### PR TITLE
Actually validate the script in `Evaluator::with_pac_script`

### DIFF
--- a/paclib/src/engine.rs
+++ b/paclib/src/engine.rs
@@ -21,7 +21,7 @@ pub struct Engine {
 }
 
 impl Engine {
-    fn mkjs(my_ip_addr: Arc<Mutex<IpAddr>>) -> Context {
+    fn mkjs(my_ip_addr: Arc<Mutex<IpAddr>>, install_default_pac: bool) -> Context {
         let mut js = Context::default();
 
         js.register_global_class::<DnsCache>().unwrap();
@@ -71,8 +71,10 @@ impl Engine {
 
         js.eval(Source::from_bytes(PAC_UTILS))
             .expect("eval pac_utils.js");
-        js.eval(Source::from_bytes(crate::DEFAULT_PAC_SCRIPT))
-            .expect("eval default PAC script");
+        if install_default_pac {
+            js.eval(Source::from_bytes(crate::DEFAULT_PAC_SCRIPT))
+                .expect("eval default PAC script");
+        }
         js
     }
 
@@ -80,7 +82,7 @@ impl Engine {
         let my_ip_addr = Arc::new(Mutex::new(IpAddr::from(std::net::Ipv4Addr::new(
             127, 0, 0, 1,
         ))));
-        let js = Self::mkjs(my_ip_addr.clone());
+        let js = Self::mkjs(my_ip_addr.clone(), true);
 
         Self { js, my_ip_addr }
     }
@@ -92,11 +94,22 @@ impl Engine {
     }
 
     pub fn set_pac_script(&mut self, pac_script: Option<&str>) -> Result<(), PacScriptError> {
-        self.js = Self::mkjs(self.my_ip_addr.clone());
+        let install_default_pac = pac_script.is_none();
+        let mut js = Self::mkjs(self.my_ip_addr.clone(), install_default_pac);
         let pac_script = pac_script.unwrap_or(crate::DEFAULT_PAC_SCRIPT);
-        self.js
+        js
             .eval(Source::from_bytes(pac_script))
             .map_err(|e| PacScriptError::InternalError(e.to_string()))?;
+        if !install_default_pac {
+            let find_proxy_fn = js
+                .global_object()
+                .get(js_string!("FindProxyForURL"), &mut js)
+                .map_err(|e| PacScriptError::InternalError(e.to_string()))?;
+            if !find_proxy_fn.is_callable() {
+                return Err(PacScriptError::FindProxyForURLMissing);
+            }
+        }
+        self.js = js;
         Ok(())
     }
 
@@ -116,9 +129,13 @@ impl Engine {
             .js
             .global_object()
             .get(js_string!("FindProxyForURL"), &mut self.js)
-            .map_err(|e| FindProxyError::InternalError(e.to_string()))?
+            .map_err(|e| FindProxyError::InternalError(e.to_string()))?;
+        if !find_proxy_fn.is_callable() {
+            return Err(FindProxyError::FindProxyForURLMissing);
+        }
+        let find_proxy_fn = find_proxy_fn
             .as_object()
-            .ok_or(FindProxyError::FindProxyForURLMissing)?;
+            .expect("callable FindProxyForURL is an object");
 
         let uri = JsValue::from(JsString::from(uri.to_string()));
         let host = JsValue::from(JsString::from(host));

--- a/paclib/src/engine.rs
+++ b/paclib/src/engine.rs
@@ -97,8 +97,7 @@ impl Engine {
         let install_default_pac = pac_script.is_none();
         let mut js = Self::mkjs(self.my_ip_addr.clone(), install_default_pac);
         let pac_script = pac_script.unwrap_or(crate::DEFAULT_PAC_SCRIPT);
-        js
-            .eval(Source::from_bytes(pac_script))
+        js.eval(Source::from_bytes(pac_script))
             .map_err(|e| PacScriptError::InternalError(e.to_string()))?;
         if !install_default_pac {
             let find_proxy_fn = js

--- a/paclib/src/evaluator.rs
+++ b/paclib/src/evaluator.rs
@@ -46,22 +46,14 @@ impl Evaluator {
 
         let worker = thread::Builder::new()
             .name("pac-eval-worker".into())
-            .spawn(move || {
-                Self::run(
-                    receiver,
-                    Some(pac_script),
-                    Some(initialized_sender),
-                )
-            })
+            .spawn(move || Self::run(receiver, Some(pac_script), Some(initialized_sender)))
             .expect("create thread");
 
-        initialized_receiver
-            .recv()
-            .map_err(|_| {
-                PacScriptError::InternalError(
-                    "PAC evaluator worker stopped during initialization".into(),
-                )
-            })??;
+        initialized_receiver.recv().map_err(|_| {
+            PacScriptError::InternalError(
+                "PAC evaluator worker stopped during initialization".into(),
+            )
+        })??;
 
         Ok(Self {
             _worker: Arc::new(worker),
@@ -160,10 +152,7 @@ mod tests {
     fn with_pac_script_reports_syntax_errors() {
         let result = Evaluator::with_pac_script("function FindProxyForURL(url, host) {");
 
-        assert!(matches!(
-            result,
-            Err(PacScriptError::InternalError(_))
-        ));
+        assert!(matches!(result, Err(PacScriptError::InternalError(_))));
     }
 
     #[test]

--- a/paclib/src/evaluator.rs
+++ b/paclib/src/evaluator.rs
@@ -30,7 +30,7 @@ impl Evaluator {
 
         let worker = thread::Builder::new()
             .name("pac-eval-worker".into())
-            .spawn(move || Self::run(receiver, None))
+            .spawn(move || Self::run(receiver, None, None))
             .expect("create thread");
 
         Self {
@@ -42,22 +42,46 @@ impl Evaluator {
     pub fn with_pac_script(pac_script: &str) -> Result<Self, PacScriptError> {
         let pac_script = pac_script.to_owned();
         let (sender, receiver) = mpsc::channel::<Action>();
+        let (initialized_sender, initialized_receiver) = mpsc::sync_channel(1);
 
         let worker = thread::Builder::new()
             .name("pac-eval-worker".into())
-            .spawn(move || Self::run(receiver, Some(pac_script)))
+            .spawn(move || {
+                Self::run(
+                    receiver,
+                    Some(pac_script),
+                    Some(initialized_sender),
+                )
+            })
             .expect("create thread");
 
-        let new = Self {
+        initialized_receiver
+            .recv()
+            .map_err(|_| {
+                PacScriptError::InternalError(
+                    "PAC evaluator worker stopped during initialization".into(),
+                )
+            })??;
+
+        Ok(Self {
             _worker: Arc::new(worker),
             sender: Mutex::new(Some(sender)),
-        };
-        Ok(new)
+        })
     }
 
-    fn run(receiver: mpsc::Receiver<Action>, pac_script: Option<String>) {
+    fn run(
+        receiver: mpsc::Receiver<Action>,
+        pac_script: Option<String>,
+        initialized_sender: Option<mpsc::SyncSender<SetPacScriptResult>>,
+    ) {
         let mut engine = Engine::new();
-        engine.set_pac_script(pac_script.as_deref()).ok();
+        if let Some(initialized_sender) = initialized_sender {
+            let result = engine.set_pac_script(pac_script.as_deref());
+            let failed = result.is_err();
+            if initialized_sender.send(result).is_err() || failed {
+                return;
+            }
+        }
 
         while let Ok(action) = receiver.recv() {
             match action {
@@ -124,5 +148,46 @@ impl Drop for Evaluator {
         let mut sender = self.sender.lock().unwrap();
         let _ = sender.take();
         // self.worker.join();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Evaluator;
+    use crate::{PacScriptError, Proxies, ProxyOrDirect};
+
+    #[test]
+    fn with_pac_script_reports_syntax_errors() {
+        let result = Evaluator::with_pac_script("function FindProxyForURL(url, host) {");
+
+        assert!(matches!(
+            result,
+            Err(PacScriptError::InternalError(_))
+        ));
+    }
+
+    #[test]
+    fn with_pac_script_reports_missing_entry_function() {
+        let result = Evaluator::with_pac_script(
+            "function FindProxyForUrl(url, host) { return \"DIRECT\"; }",
+        );
+
+        assert!(matches!(
+            result,
+            Err(PacScriptError::FindProxyForURLMissing)
+        ));
+    }
+
+    #[tokio::test]
+    async fn new_keeps_the_default_pac_function() {
+        let evaluator = Evaluator::new();
+
+        assert_eq!(
+            evaluator
+                .find_proxy("http://localhost/".parse().unwrap())
+                .await
+                .unwrap(),
+            Proxies::new(vec![ProxyOrDirect::Direct])
+        );
     }
 }

--- a/paclib/src/lib.rs
+++ b/paclib/src/lib.rs
@@ -27,6 +27,8 @@ pub enum CreateEvaluatorError {
 pub enum PacScriptError {
     #[error("internal error: {0}")]
     InternalError(String),
+    #[error("FindProxyForURL function missing in PAC script")]
+    FindProxyForURLMissing,
     #[error("I/O error: {0}")]
     Io(
         #[from]


### PR DESCRIPTION

`with_pac_script` returns `Result`, but it can't actually fail: construction returns before the worker evaluates the script, and the worker throws the result away. A script with a syntax error gives you `Ok(Evaluator)`. And since a default `FindProxyForURL` is installed first, a script with a misspelled entry function just silently routes everything `DIRECT`.

Now the script is evaluated during construction, and you get an `Err` for syntax errors or a missing/non-function `FindProxyForURL`.
