### PR TITLE
Don't kill the daemon on a failed PAC reload

### DIFF
--- a/paclib/src/engine.rs
+++ b/paclib/src/engine.rs
@@ -94,8 +94,7 @@ impl Engine {
     pub fn set_pac_script(&mut self, pac_script: Option<&str>) -> Result<(), PacScriptError> {
         let mut js = Self::mkjs(self.my_ip_addr.clone());
         let pac_script = pac_script.unwrap_or(crate::DEFAULT_PAC_SCRIPT);
-        js
-            .eval(Source::from_bytes(pac_script))
+        js.eval(Source::from_bytes(pac_script))
             .map_err(|e| PacScriptError::InternalError(e.to_string()))?;
         self.js = js;
         Ok(())
@@ -231,8 +230,8 @@ fn my_ip_address(
 mod tests {
     use super::Engine;
     use super::Uri;
-    use crate::Proxy;
     use crate::Proxies;
+    use crate::Proxy;
     use crate::ProxyOrDirect;
 
     #[test]
@@ -264,9 +263,10 @@ mod tests {
         )?;
         let uri = "http://localhost/".parse::<Uri>()?;
 
-        assert!(eval
-            .set_pac_script(Some("function FindProxyForURL(url, host) {"))
-            .is_err());
+        assert!(
+            eval.set_pac_script(Some("function FindProxyForURL(url, host) {"))
+                .is_err()
+        );
         assert_eq!(
             eval.find_proxy(&uri)?,
             Proxies::new(vec![ProxyOrDirect::Proxy(Proxy::Http(

--- a/paclib/src/engine.rs
+++ b/paclib/src/engine.rs
@@ -92,11 +92,12 @@ impl Engine {
     }
 
     pub fn set_pac_script(&mut self, pac_script: Option<&str>) -> Result<(), PacScriptError> {
-        self.js = Self::mkjs(self.my_ip_addr.clone());
+        let mut js = Self::mkjs(self.my_ip_addr.clone());
         let pac_script = pac_script.unwrap_or(crate::DEFAULT_PAC_SCRIPT);
-        self.js
+        js
             .eval(Source::from_bytes(pac_script))
             .map_err(|e| PacScriptError::InternalError(e.to_string()))?;
+        self.js = js;
         Ok(())
     }
 
@@ -230,6 +231,7 @@ fn my_ip_address(
 mod tests {
     use super::Engine;
     use super::Uri;
+    use crate::Proxy;
     use crate::Proxies;
     use crate::ProxyOrDirect;
 
@@ -251,6 +253,42 @@ mod tests {
         assert_eq!(
             eval.find_proxy(&"http://localhost/".parse::<Uri>().unwrap())?,
             Proxies::new(vec![ProxyOrDirect::Direct])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn failed_script_update_retains_previous_route() -> Result<(), Box<dyn std::error::Error>> {
+        let mut eval = Engine::with_pac_script(
+            "function FindProxyForURL(url, host) { return \"PROXY 127.0.0.1:3128\"; }",
+        )?;
+        let uri = "http://localhost/".parse::<Uri>()?;
+
+        assert!(eval
+            .set_pac_script(Some("function FindProxyForURL(url, host) {"))
+            .is_err());
+        assert_eq!(
+            eval.find_proxy(&uri)?,
+            Proxies::new(vec![ProxyOrDirect::Proxy(Proxy::Http(
+                "127.0.0.1:3128".parse()?,
+            ))])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn script_update_retains_my_ip_address() -> Result<(), Box<dyn std::error::Error>> {
+        let mut eval = Engine::new();
+        eval.set_my_ip_address("192.0.2.1".parse()?)?;
+        eval.set_pac_script(Some(
+            "function FindProxyForURL(url, host) { return myIpAddress() === \"192.0.2.1\" ? \"PROXY 127.0.0.1:3128\" : \"DIRECT\"; }",
+        ))?;
+
+        assert_eq!(
+            eval.find_proxy(&"http://localhost/".parse::<Uri>()?)?,
+            Proxies::new(vec![ProxyOrDirect::Proxy(Proxy::Http(
+                "127.0.0.1:3128".parse()?,
+            ))])
         );
         Ok(())
     }

--- a/proxydetox/src/main.rs
+++ b/proxydetox/src/main.rs
@@ -193,12 +193,24 @@ async fn run(config: Arc<Options>) -> Result<(), proxydetoxlib::Error> {
     let joiner = loop {
         tokio::select! {
             _ = reload_trigger() => {
-                context.load_pac_file(&config.pac_file).await?;
-                context.set_my_ip_address(my_ip_address()).await?;
+                match context.load_pac_file(&config.pac_file).await {
+                    Ok(()) => {
+                        context.set_my_ip_address(my_ip_address()).await?;
+                    }
+                    Err(cause) => {
+                        tracing::error!(%cause, pac_file=?config.pac_file, "failed to reload PAC");
+                    }
+                }
             },
             _ = direct_mode_trigger() => {
-                context.load_pac_file(&None).await?;
-                context.set_my_ip_address(my_ip_address()).await?;
+                match context.load_pac_file(&None).await {
+                    Ok(()) => {
+                        context.set_my_ip_address(my_ip_address()).await?;
+                    }
+                    Err(cause) => {
+                        tracing::error!(%cause, "failed to switch to direct mode");
+                    }
+                }
             },
             _ = shutdown_trigger() => {
                 tracing::info!("shutdown requested");


### PR DESCRIPTION
Two problems here. First, a reload error propagates all the way up and exits the daemon — so a transient download hiccup or a syntax error in a newly pushed PAC takes the whole proxy offline. Second, the engine swaps in the new JS context before validating the script, so even callers who catch the error are left without a working policy.

Now the new script is validated in a scratch context first. If it's bad, the last known-good policy keeps running, the error gets logged, and the daemon stays up.