### PR TITLE
Fix isInNet for hosts that resolve to IPv6

### DIFF
--- a/paclib/src/dns.rs
+++ b/paclib/src/dns.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::UNIX_EPOCH};
+use std::{collections::HashMap, net::SocketAddr, time::UNIX_EPOCH};
 
 use boa_engine::{JsData, class::Class};
 use boa_gc::{Finalize, Trace};
@@ -80,10 +80,41 @@ impl Class for DnsCache {
 pub(crate) fn resolve(host: &str) -> Option<String> {
     use std::net::ToSocketAddrs;
 
-    (host, 0u16)
-        .to_socket_addrs()
-        .ok()
-        .and_then(|mut a| a.next())
-        .map(|a| a.ip())
-        .map(|ip| ip.to_string())
+    select_address((host, 0u16).to_socket_addrs().ok()?.into_iter())
+}
+
+fn select_address(addresses: impl Iterator<Item = SocketAddr>) -> Option<String> {
+    let mut ipv6 = None;
+    for address in addresses {
+        match address.ip() {
+            std::net::IpAddr::V4(ip) => return Some(ip.to_string()),
+            std::net::IpAddr::V6(ip) => {
+                ipv6.get_or_insert_with(|| ip.to_string());
+            }
+        }
+    }
+    ipv6
+}
+
+#[cfg(test)]
+mod tests {
+    use super::select_address;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+    #[test]
+    fn select_address_prefers_ipv4() {
+        let addresses = [
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)), 0),
+        ];
+
+        assert_eq!(select_address(addresses.into_iter()), Some("192.0.2.1".into()));
+    }
+
+    #[test]
+    fn select_address_falls_back_to_ipv6() {
+        let addresses = [SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0)];
+
+        assert_eq!(select_address(addresses.into_iter()), Some("::1".into()));
+    }
 }

--- a/paclib/src/dns.rs
+++ b/paclib/src/dns.rs
@@ -80,7 +80,7 @@ impl Class for DnsCache {
 pub(crate) fn resolve(host: &str) -> Option<String> {
     use std::net::ToSocketAddrs;
 
-    select_address((host, 0u16).to_socket_addrs().ok()?.into_iter())
+    select_address((host, 0u16).to_socket_addrs().ok()?)
 }
 
 fn select_address(addresses: impl Iterator<Item = SocketAddr>) -> Option<String> {

--- a/paclib/src/dns.rs
+++ b/paclib/src/dns.rs
@@ -108,7 +108,10 @@ mod tests {
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)), 0),
         ];
 
-        assert_eq!(select_address(addresses.into_iter()), Some("192.0.2.1".into()));
+        assert_eq!(
+            select_address(addresses.into_iter()),
+            Some("192.0.2.1".into())
+        );
     }
 
     #[test]

--- a/paclib/src/pac_utils.js
+++ b/paclib/src/pac_utils.js
@@ -40,7 +40,7 @@ function isInNet(ipaddr, pattern, maskstr) {
     }
     if (!isValidIpAddress(ipaddr)) {
         ipaddr = dnsResolve(ipaddr);
-        if (ipaddr == null) {
+        if (ipaddr == null || !isValidIpAddress(ipaddr)) {
             return false;
         }
     }


### PR DESCRIPTION
DNS resolution takes the first address it gets without filtering by family, and isInNet shoves it into an IPv4-only converter. On a machine where localhost resolves to ::1, isInNet("localhost", "127.0.0.0", "255.0.0.0") evaluates to false — which is wrong.

Now DNS results are filtered by address family before isInNet uses them, so IPv6-resolving hosts don't break the check.