### PR TITLE
Don't fall back to DIRECT when PAC evaluation fails

### DIFF
--- a/proxydetoxlib/src/context.rs
+++ b/proxydetoxlib/src/context.rs
@@ -70,19 +70,22 @@ impl Context {
         Default::default()
     }
 
-    pub(super) async fn find_proxy(&self, uri: Uri) -> paclib::Proxies {
+    pub(super) async fn find_proxy(
+        &self,
+        uri: Uri,
+    ) -> Result<paclib::Proxies, paclib::FindProxyError> {
         let mut proxies = self
             .eval
             .find_proxy(uri.clone())
             .await
-            .unwrap_or_else(|cause| {
+            .map_err(|cause| {
                 tracing::error!(%cause, %uri, "failed to find_proxy");
-                paclib::Proxies::direct()
-            });
+                cause
+            })?;
         if self.direct_fallback && !proxies.iter().any(|p| *p == ProxyOrDirect::Direct) {
             proxies.push(ProxyOrDirect::Direct);
         }
-        proxies
+        Ok(proxies)
     }
 
     #[instrument(skip(self))]

--- a/proxydetoxlib/src/context.rs
+++ b/proxydetoxlib/src/context.rs
@@ -74,14 +74,10 @@ impl Context {
         &self,
         uri: Uri,
     ) -> Result<paclib::Proxies, paclib::FindProxyError> {
-        let mut proxies = self
-            .eval
-            .find_proxy(uri.clone())
-            .await
-            .map_err(|cause| {
-                tracing::error!(%cause, %uri, "failed to find_proxy");
-                cause
-            })?;
+        let mut proxies = self.eval.find_proxy(uri.clone()).await.map_err(|cause| {
+            tracing::error!(%cause, %uri, "failed to find_proxy");
+            cause
+        })?;
         if self.direct_fallback && !proxies.iter().any(|p| *p == ProxyOrDirect::Direct) {
             proxies.push(ProxyOrDirect::Direct);
         }

--- a/proxydetoxlib/src/session.rs
+++ b/proxydetoxlib/src/session.rs
@@ -61,6 +61,12 @@ lazy_static! {
 pub enum Error {
     #[error("invalid URI")]
     InvalidUri,
+    #[error("PAC evaluation error: {0}")]
+    PacEvaluation(
+        #[from]
+        #[source]
+        paclib::FindProxyError,
+    ),
     #[error("invalid host: {0}")]
     InvalidHost(
         #[source]
@@ -175,7 +181,7 @@ impl Inner {
                 .build()
                 .expect("URI")
         };
-        let proxies = self.context.find_proxy(uri.clone()).await;
+        let proxies = self.context.find_proxy(uri.clone()).await?;
         let conn = proxies.clone().into_iter().map({
             let cx = self.context.clone();
             let method = req.method();

--- a/proxydetoxlib/tests/http_direct.rs
+++ b/proxydetoxlib/tests/http_direct.rs
@@ -2,6 +2,8 @@ mod environment;
 
 use crate::environment::{Environment, httpd, read_to_string};
 use http::{Request, Response, header::PROXY_AUTHORIZATION};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn http_get_request() {
@@ -58,8 +60,11 @@ async fn pac_script_error() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn pac_script_invalid_result() {
-    let http1 = httpd::Server::new(|_r| {
-        {
+    let requests = Arc::new(AtomicUsize::new(0));
+    let http1 = httpd::Server::new({
+        let requests = requests.clone();
+        move |_r| {
+            requests.fetch_add(1, Ordering::Relaxed);
             Response::builder()
                 .body(crate::environment::full(String::from("Hello World!")))
                 .unwrap()
@@ -79,7 +84,8 @@ async fn pac_script_invalid_result() {
 
     let resp = env.send(req).await;
 
-    assert_eq!(resp.status(), http::StatusCode::OK);
+    assert_eq!(resp.status(), http::StatusCode::BAD_GATEWAY);
+    assert_eq!(requests.load(Ordering::Relaxed), 0);
 
     tokio::join!(env.shutdown(), http1.shutdown());
 }

--- a/proxydetoxlib/tests/http_direct.rs
+++ b/proxydetoxlib/tests/http_direct.rs
@@ -2,8 +2,8 @@ mod environment;
 
 use crate::environment::{Environment, httpd, read_to_string};
 use http::{Request, Response, header::PROXY_AUTHORIZATION};
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn http_get_request() {


### PR DESCRIPTION
Right now, any error during PAC evaluation — a JS exception, a malformed proxy list, whatever — silently turns into DIRECT, and it does so regardless of whether `--direct-fallback` is set. That means a single broken PAC can leak traffic straight out to the internet, which defeats the point of running a mandatory proxy.

This makes evaluation errors respect `--direct-fallback` by default. The request is rejected, and it only falls back to direct when the user explicitly opted in.