### PR TITLE
Wait for the PAC file before accepting connections

### DIFF
--- a/proxydetox/src/main.rs
+++ b/proxydetox/src/main.rs
@@ -152,7 +152,8 @@ async fn run(config: Arc<Options>) -> Result<(), proxydetoxlib::Error> {
         .parallel_connect(config.parallel_connect)
         .direct_fallback(config.direct_fallback)
         .client_tcp_keepalive(config.client_tcp_keepalive.clone())
-        .build();
+        .build()
+        .await?;
 
     if let Some(my_ip) = config.my_ip_address {
         context.set_my_ip_address(my_ip).await?;

--- a/proxydetoxlib/src/context/builder.rs
+++ b/proxydetoxlib/src/context/builder.rs
@@ -82,7 +82,7 @@ impl Builder {
         self
     }
 
-    pub fn build(self) -> Arc<Context> {
+    pub async fn build(self) -> std::io::Result<Arc<Context>> {
         let auth = self.auth.unwrap_or(AuthenticatorFactory::None);
         let eval = if let Some(pac) = self.pac_script {
             Evaluator::with_pac_script(&pac).unwrap_or_default()
@@ -90,17 +90,8 @@ impl Builder {
             Evaluator::new()
         };
         let tls_config = self.tls_config.unwrap_or_else(default_tls_config);
+        let pac_file = self.pac_file;
         let (accesslog_tx, mut accesslog_rx) = broadcast::channel(16);
-        tokio::spawn(async move {
-            loop {
-                let entry = accesslog_rx.recv().await;
-                if let Err(cause) = entry
-                    && cause == broadcast::error::RecvError::Closed
-                {
-                    break;
-                }
-            }
-        });
         let context = Context {
             eval,
             auth,
@@ -115,18 +106,22 @@ impl Builder {
         };
         let context = Arc::new(context);
 
-        if self.pac_file.is_some() {
-            tokio::spawn({
-                let context = context.clone();
-                async move {
-                    if let Err(cause) = context.load_pac_file(&self.pac_file).await {
-                        tracing::error!(%cause, pac_file = ?&self.pac_file, "failed to load PAC from URI");
-                    }
-                }
-            });
+        if pac_file.is_some() {
+            context.load_pac_file(&pac_file).await?;
         }
 
-        context
+        tokio::spawn(async move {
+            loop {
+                let entry = accesslog_rx.recv().await;
+                if let Err(cause) = entry
+                    && cause == broadcast::error::RecvError::Closed
+                {
+                    break;
+                }
+            }
+        });
+
+        Ok(context)
     }
 }
 
@@ -141,4 +136,71 @@ fn default_tls_config() -> Arc<rustls::ClientConfig> {
         .with_no_client_auth();
 
     Arc::new(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Builder;
+    use detox_net::PathOrUri;
+    use paclib::{Proxy, ProxyOrDirect, Proxies};
+    use std::fs;
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+
+    fn init_crypto_provider() {
+        INIT.call_once(|| {
+            rustls::crypto::CryptoProvider::install_default(
+                rustls::crypto::aws_lc_rs::default_provider(),
+            )
+            .expect("CryptoProvider::install_default");
+        });
+    }
+
+    #[tokio::test]
+    async fn build_waits_for_pac_file() -> Result<(), Box<dyn std::error::Error>> {
+        init_crypto_provider();
+        let path = std::env::temp_dir().join(format!(
+            "proxydetox-pac-{}-{}.pac",
+            std::process::id(),
+            "build_waits_for_pac_file"
+        ));
+        fs::write(
+            &path,
+            "function FindProxyForURL(url, host) { return \"PROXY 127.0.0.1:3128\"; }",
+        )?;
+
+        let context = Builder::default()
+            .pac_file(Some(PathOrUri::from(path.clone())))
+            .build()
+            .await?;
+        let proxies = context
+            .eval
+            .find_proxy("http://example.org/".parse()?)
+            .await?;
+
+        fs::remove_file(path)?;
+        assert_eq!(
+            proxies,
+            Proxies::new(vec![ProxyOrDirect::Proxy(Proxy::Http(
+                "127.0.0.1:3128".parse()?,
+            ))])
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn build_reports_pac_file_failure() {
+        init_crypto_provider();
+        let path = std::env::temp_dir().join(format!(
+            "proxydetox-pac-{}-missing.pac",
+            std::process::id()
+        ));
+        let result = Builder::default()
+            .pac_file(Some(PathOrUri::from(path)))
+            .build()
+            .await;
+
+        assert!(result.is_err());
+    }
 }

--- a/proxydetoxlib/src/context/builder.rs
+++ b/proxydetoxlib/src/context/builder.rs
@@ -142,7 +142,7 @@ fn default_tls_config() -> Arc<rustls::ClientConfig> {
 mod tests {
     use super::Builder;
     use detox_net::PathOrUri;
-    use paclib::{Proxy, ProxyOrDirect, Proxies};
+    use paclib::{Proxies, Proxy, ProxyOrDirect};
     use std::fs;
     use std::sync::Once;
 
@@ -192,10 +192,8 @@ mod tests {
     #[tokio::test]
     async fn build_reports_pac_file_failure() {
         init_crypto_provider();
-        let path = std::env::temp_dir().join(format!(
-            "proxydetox-pac-{}-missing.pac",
-            std::process::id()
-        ));
+        let path =
+            std::env::temp_dir().join(format!("proxydetox-pac-{}-missing.pac", std::process::id()));
         let result = Builder::default()
             .pac_file(Some(PathOrUri::from(path)))
             .build()

--- a/proxydetoxlib/tests/environment/mod.rs
+++ b/proxydetoxlib/tests/environment/mod.rs
@@ -150,7 +150,9 @@ impl Builder {
             )
             .authenticator_factory(auth)
             .proxytunnel(self.proxytunnel)
-            .build();
+            .build()
+            .await
+            .expect("build context");
 
         let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
             .await


### PR DESCRIPTION
The PAC loader runs in a detached task while the server starts listening immediately. If the PAC is remote and slow to download, the first requests get handled with the default DIRECT policy. If the download fails permanently, we just log it and keep going with DIRECT forever.

Now the initial load is awaited before the listener comes up, and a failed initial load is a startup error. No more "we're up, but actually proxying everything direct" window.