### PR TITLE
fix: update dnsdetox mutable binding

### DIFF
--- a/dnsdetox/src/dns.rs
+++ b/dnsdetox/src/dns.rs
@@ -71,7 +71,7 @@ impl Stream for RequestStream {
     ) -> std::task::Poll<Option<Self::Item>> {
         let Self {
             socket,
-            ref mut data,
+            data,
         } = self.get_mut();
         let mut data = Pin::new(data);
         let mut buffer = ReadBuf::new(&mut data);


### PR DESCRIPTION
cargo test --workspace failed on main because Rust rejected the redundant ref mut binding in dnsdetox/src/dns.rs. Remove the modifier so the workspace compiles. Validation: cargo test --workspace (56 passed, 0 failed).