### PR TITLE
fix(paclib): correct PAC range semantics

### DIFF
--- a/paclib/src/pac_utils.js
+++ b/paclib/src/pac_utils.js
@@ -91,7 +91,7 @@ function weekdayRange() {
     var wd2 = (argc == 2) ? getDay(arguments[1]) : wd1;
     return (wd1 == -1 || wd2 == -1) ? false
         : (wd1 <= wd2) ? (wd1 <= wday && wday <= wd2)
-            : (wd2 >= wday || wday >= wd1);
+            : (wday == wd1 || wday == wd2);
 }
 
 function dateRange() {
@@ -110,6 +110,37 @@ function dateRange() {
 
     if (isGMT) {
         argc--;
+    }
+    if (argc == 2) {
+        var first = parseInt(arguments[0]);
+        var second = parseInt(arguments[1]);
+        if ((first < 32 && isNaN(second)) ||
+            (isNaN(first) && second < 32)) {
+            var day = first < 32 ? first : second;
+            var month = getMonth(first < 32 ? arguments[1] : arguments[0]);
+            return month >= 0 && day >= 1 && day < 32 &&
+                (isGMT ? date.getUTCDate() : date.getDate()) == day &&
+                (isGMT ? date.getUTCMonth() : date.getMonth()) == month;
+        }
+    } else if (argc == 3) {
+        var day = -1;
+        var month = -1;
+        var year = -1;
+        for (var i = 0; i < argc; i++) {
+            var value = parseInt(arguments[i]);
+            if (isNaN(value)) {
+                month = getMonth(arguments[i]);
+            } else if (value < 32) {
+                day = value;
+            } else {
+                year = value;
+            }
+        }
+        if (day >= 1 && day < 32 && month >= 0 && year > 31) {
+            return (isGMT ? date.getUTCDate() : date.getDate()) == day &&
+                (isGMT ? date.getUTCMonth() : date.getMonth()) == month &&
+                (isGMT ? date.getUTCFullYear() : date.getFullYear()) == year;
+        }
     }
     // function will work even without explict handling of this case
     if (argc == 1) {
@@ -191,7 +222,9 @@ function timeRange() {
     if (argc == 1) {
         return (hour == arguments[0]);
     } else if (argc == 2) {
-        return ((arguments[0] <= hour) && (hour <= arguments[1]));
+        return (arguments[0] <= arguments[1])
+            ? ((arguments[0] <= hour) && (hour <= arguments[1]))
+            : (hour == arguments[0] || hour == arguments[1]);
     } else {
         switch (argc) {
             case 6:

--- a/paclib/tests/pac_utils.rs
+++ b/paclib/tests/pac_utils.rs
@@ -76,6 +76,86 @@ fn test_sh_exp_match() {
         "bad.local",
     );
 }
+
+#[test]
+fn test_weekday_range_reversed_bounds() {
+    let pac_script = r#"
+        function FindProxyForURL(url, host) {
+            var weekdays = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
+            var current = new Date().getDay();
+            for (var first = 1; first < weekdays.length; first++) {
+                for (var second = 0; second < first; second++) {
+                    var expected = current == first || current == second;
+                    if (weekdayRange(weekdays[first], weekdays[second]) != expected) {
+                        return "PROXY example.org:3128";
+                    }
+                }
+            }
+            return "DIRECT";
+        }
+    "#;
+    let mut eval = Engine::with_pac_script(pac_script).unwrap();
+
+    assert_eq!(
+        ProxyOrDirect::Direct,
+        eval.find_proxy(&"http://localhost/".parse::<Uri>().unwrap())
+            .unwrap()
+            .first()
+    );
+}
+
+#[test]
+fn test_time_range_reversed_bounds() {
+    let pac_script = r#"
+        function FindProxyForURL(url, host) {
+            var current = new Date().getHours();
+            var first = current == 23 ? 23 : current + 1;
+            var second = current == 23 ? 22 : current;
+            var expected = current == first || current == second;
+            return timeRange(first, second) == expected
+                ? "DIRECT"
+                : "PROXY example.org:3128";
+        }
+    "#;
+    let mut eval = Engine::with_pac_script(pac_script).unwrap();
+
+    assert_eq!(
+        ProxyOrDirect::Direct,
+        eval.find_proxy(&"http://localhost/".parse::<Uri>().unwrap())
+            .unwrap()
+            .first()
+    );
+}
+
+#[test]
+fn test_date_range_exact_day_and_month() {
+    let pac_script = r#"
+        function FindProxyForURL(url, host) {
+            var months = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN",
+                "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"];
+            var current = new Date();
+            for (var month = 0; month < months.length; month++) {
+                for (var day = 1; day <= 31; day++) {
+                    var expected = current.getMonth() == month &&
+                        current.getDate() == day;
+                    if (dateRange(day, months[month]) != expected) {
+                        return "PROXY example.org:3128";
+                    }
+                }
+            }
+            return "DIRECT";
+        }
+    "#;
+    let mut eval = Engine::with_pac_script(pac_script).unwrap();
+
+    assert_eq!(
+        ProxyOrDirect::Direct,
+        eval.find_proxy(&"http://localhost/".parse::<Uri>().unwrap())
+            .unwrap()
+            .first()
+    );
+}
+
 #[test]
 fn test_my_ip_address() {
     let pac_script = r#"


### PR DESCRIPTION
## Summary
- make reversed `weekdayRange` bounds match only their endpoint days
- make reversed two-argument `timeRange` bounds match only their endpoint hours
- support exact `dateRange(day, month)` and `dateRange(day, month, year)` forms

## Tests
- `cargo test -p paclib`
- `cargo fmt --all -- --check`
- `git diff --check`