### PR TITLE
feat: support multiple PAC files

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -80,8 +80,10 @@ clear text on disk and the password is transferred unencrypted.
 ## Proxy Auto-Configuration (PAC) file
 
 A copy of the PAC file `proxy.pac` must be places in on of directories searched
-by Proxydetox or specified via the `--pac-file` option. The PAC file can be also
-a HTTP URL. The content will then be downloaded from the given location.
+by Proxydetox or specified via the `--pac-file` option. The option may be
+specified more than once; files are evaluated in the order given and the first
+file returning a proxy is used. PAC files can be local paths (including
+symlinks) or HTTP URLs. HTTP files are downloaded from the given location.
 
 The PAC file is usually
 maintained by the network administrators. The path (usually some http location
@@ -96,6 +98,10 @@ proxydetox --pac-file http://example.org/proxy.pac
 
 ```sh
 proxydetox --pac-file /tmp/test.pac
+```
+
+```sh
+proxydetox --pac-file /tmp/corporate.pac --pac-file https://example.org/proxy.pac
 ```
 
 ## Configuration options

--- a/paclib/src/evaluator.rs
+++ b/paclib/src/evaluator.rs
@@ -20,7 +20,7 @@ type SetMyIpAddressResult = Result<(), Infallible>;
 
 enum Action {
     FindProxy(Uri, oneshot::Sender<FindProxyResult>),
-    SetPacScript(Option<String>, oneshot::Sender<SetPacScriptResult>),
+    SetPacScripts(Vec<String>, oneshot::Sender<SetPacScriptResult>),
     SetMyIpAddress(IpAddr, oneshot::Sender<SetMyIpAddressResult>),
 }
 
@@ -30,7 +30,7 @@ impl Evaluator {
 
         let worker = thread::Builder::new()
             .name("pac-eval-worker".into())
-            .spawn(move || Self::run(receiver, None))
+            .spawn(move || Self::run(receiver, Vec::new()))
             .expect("create thread");
 
         Self {
@@ -40,12 +40,16 @@ impl Evaluator {
     }
 
     pub fn with_pac_script(pac_script: &str) -> Result<Self, PacScriptError> {
-        let pac_script = pac_script.to_owned();
+        Self::with_pac_scripts(vec![pac_script.to_owned()])
+    }
+
+    pub fn with_pac_scripts(pac_scripts: Vec<String>) -> Result<Self, PacScriptError> {
         let (sender, receiver) = mpsc::channel::<Action>();
 
+        let initial_scripts = pac_scripts.clone();
         let worker = thread::Builder::new()
             .name("pac-eval-worker".into())
-            .spawn(move || Self::run(receiver, Some(pac_script)))
+            .spawn(move || Self::run(receiver, initial_scripts))
             .expect("create thread");
 
         let new = Self {
@@ -55,26 +59,49 @@ impl Evaluator {
         Ok(new)
     }
 
-    fn run(receiver: mpsc::Receiver<Action>, pac_script: Option<String>) {
-        let mut engine = Engine::new();
-        engine.set_pac_script(pac_script.as_deref()).ok();
+    fn run(receiver: mpsc::Receiver<Action>, pac_scripts: Vec<String>) {
+        let mut engines = Self::engines(pac_scripts).unwrap_or_default();
 
         while let Ok(action) = receiver.recv() {
             match action {
                 Action::FindProxy(ref uri, result) => {
-                    let r = engine.find_proxy(uri);
+                    let r = engines
+                        .iter_mut()
+                        .map(|engine| engine.find_proxy(uri))
+                        .find(|result| {
+                            result
+                                .as_ref()
+                                .map(|proxies| {
+                                    proxies
+                                        .iter()
+                                        .any(|proxy| !matches!(proxy, crate::ProxyOrDirect::Direct))
+                                })
+                                .unwrap_or(true)
+                        })
+                        .unwrap_or_else(|| Ok(crate::Proxies::direct()));
                     result.send(r).ok();
                 }
-                Action::SetPacScript(ref script, result) => {
-                    let r = engine.set_pac_script(script.as_deref());
+                Action::SetPacScripts(scripts, result) => {
+                    let r = Self::engines(scripts).map(|new| {
+                        engines = new;
+                    });
                     result.send(r).ok();
                 }
                 Action::SetMyIpAddress(addr, result) => {
-                    let r = engine.set_my_ip_address(addr);
+                    let r = engines
+                        .iter_mut()
+                        .try_for_each(|engine| engine.set_my_ip_address(addr));
                     result.send(r).ok();
                 }
             }
         }
+    }
+
+    fn engines(scripts: Vec<String>) -> Result<Vec<Engine>, PacScriptError> {
+        scripts
+            .into_iter()
+            .map(|script| Engine::with_pac_script(&script))
+            .collect()
     }
 
     pub async fn find_proxy(&self, uri: Uri) -> FindProxyResult {
@@ -89,12 +116,16 @@ impl Evaluator {
     }
 
     pub async fn set_pac_script(&self, pac_script: Option<String>) -> SetPacScriptResult {
+        self.set_pac_scripts(pac_script.into_iter().collect()).await
+    }
+
+    pub async fn set_pac_scripts(&self, pac_scripts: Vec<String>) -> SetPacScriptResult {
         let (tx, rx) = oneshot::channel::<SetPacScriptResult>();
         {
             let sender = self.sender.lock().unwrap();
             if let Some(ref sender) = *sender {
                 sender
-                    .send(Action::SetPacScript(pac_script, tx))
+                    .send(Action::SetPacScripts(pac_scripts, tx))
                     .expect("send");
             }
         }
@@ -124,5 +155,30 @@ impl Drop for Evaluator {
         let mut sender = self.sender.lock().unwrap();
         let _ = sender.take();
         // self.worker.join();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Evaluator;
+    use crate::{Proxy, ProxyOrDirect};
+
+    #[tokio::test]
+    async fn uses_first_pac_file_returning_a_proxy() {
+        let evaluator = Evaluator::with_pac_scripts(vec![
+            "function FindProxyForURL(url, host) { return \"DIRECT\"; }".into(),
+            "function FindProxyForURL(url, host) { return \"PROXY proxy.example:8080\"; }".into(),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            evaluator
+                .find_proxy("http://example.org/".parse().unwrap())
+                .await
+                .unwrap(),
+            crate::Proxies::new(vec![ProxyOrDirect::Proxy(Proxy::Http(
+                "proxy.example:8080".parse().unwrap()
+            ))])
+        );
     }
 }

--- a/proxydetox/src/main.rs
+++ b/proxydetox/src/main.rs
@@ -144,7 +144,7 @@ async fn run(config: Arc<Options>) -> Result<(), proxydetoxlib::Error> {
     tracing::debug!(%auth, "authorization");
 
     let context = proxydetoxlib::Context::builder()
-        .pac_file(config.pac_file.clone())
+        .pac_files(config.pac_files.clone())
         .authenticator_factory(Some(auth))
         .proxytunnel(config.proxytunnel)
         .connect_timeout(config.connect_timeout)
@@ -186,14 +186,14 @@ async fn run(config: Arc<Options>) -> Result<(), proxydetoxlib::Error> {
     let listeners = stream::select_all(listeners);
     let (server, control) = Server::new(listeners, context.clone());
 
-    tracing::info!(listening=?addrs, pac_file=?config.pac_file, "starting");
+    tracing::info!(listening=?addrs, pac_files=?config.pac_files, "starting");
 
     let server = tokio::spawn(async move { server.run().await });
     tokio::pin!(server);
     let joiner = loop {
         tokio::select! {
             _ = reload_trigger() => {
-                context.load_pac_file(&config.pac_file).await?;
+                context.load_pac_files(&config.pac_files).await?;
                 context.set_my_ip_address(my_ip_address()).await?;
             },
             _ = direct_mode_trigger() => {

--- a/proxydetox/src/options.rs
+++ b/proxydetox/src/options.rs
@@ -30,7 +30,7 @@ pub struct Options {
     pub attach_console: bool,
     pub log_level: LevelFilter,
     pub log_filepath: Option<PathBuf>,
-    pub pac_file: Option<PathOrUri>,
+    pub pac_files: Vec<PathOrUri>,
     pub my_ip_address: Option<IpAddr>,
     pub authorization: Authorization,
     pub connect_timeout: Duration,
@@ -211,7 +211,7 @@ impl Options {
                         "PAC file to be used to decide which upstream proxy to forward the request (local file path, http://, or https:// URI are accepted)",
                     )
                     .value_parser(is_file_or_http_uri)
-                    .action(clap::ArgAction::Set),
+                    .action(clap::ArgAction::Append),
             )
             .arg(
                 Arg::new("my_ip_address")
@@ -388,10 +388,10 @@ impl From<ArgMatches> for Options {
             attach_console: m.get_flag("attach_console"),
             log_level,
             log_filepath: m.get_one("log_filepath").cloned(),
-            pac_file: m
-                .get_one::<PathOrUri>("pac_file")
-                .cloned()
-                .or_else(|| which_pac_file().map(PathOrUri::Path)),
+            pac_files: m
+                .get_many::<PathOrUri>("pac_file")
+                .map(|files| files.cloned().collect())
+                .unwrap_or_else(|| which_pac_file().into_iter().map(PathOrUri::Path).collect()),
             my_ip_address: m.get_one::<IpAddr>("my_ip_address").cloned(),
             authorization,
             proxytunnel: m.get_flag("proxytunnel"),
@@ -535,8 +535,8 @@ mod tests {
             pac_file.clone().into(),
         ]);
         assert_eq!(
-            args.pac_file,
-            Some(PathOrUri::Path(PathBuf::from(&pac_file)))
+            args.pac_files,
+            vec![PathOrUri::Path(PathBuf::from(&pac_file))]
         );
     }
 
@@ -548,7 +548,27 @@ mod tests {
             "--pac-file".into(),
             proxy_pac.clone().into(),
         ]);
-        assert_eq!(args.pac_file, proxy_pac.parse().ok());
+        assert_eq!(args.pac_files, vec![proxy_pac.parse().unwrap()]);
+    }
+
+    #[test]
+    fn test_multiple_pac_files() {
+        let first = example_pac();
+        let second = "http://example.org/proxy.pac";
+        let args = Options::parse_args(&[
+            "proxydetox".into(),
+            "--pac-file".into(),
+            first.clone().into(),
+            "--pac-file".into(),
+            second.into(),
+        ]);
+        assert_eq!(
+            args.pac_files,
+            vec![
+                PathOrUri::Path(PathBuf::from(first)),
+                second.parse().unwrap()
+            ]
+        );
     }
 
     #[test]

--- a/proxydetoxlib/src/context.rs
+++ b/proxydetoxlib/src/context.rs
@@ -86,9 +86,10 @@ impl Context {
     }
 
     #[instrument(skip(self))]
-    pub async fn load_pac_file(&self, uri: &Option<PathOrUri>) -> std::io::Result<()> {
+    pub async fn load_pac_files(&self, uris: &[PathOrUri]) -> std::io::Result<()> {
         tracing::info!("update PAC script");
-        let pac = if let Some(uri) = uri {
+        let mut scripts = Vec::with_capacity(uris.len());
+        for uri in uris {
             let pac = match uri {
                 PathOrUri::Path(p) => read_to_string(p)?,
                 PathOrUri::Uri(u) => detox_hyper::http_file(u.clone(), self.tls_config.clone())
@@ -96,14 +97,16 @@ impl Context {
                     .await
                     .map_err(std::io::Error::other)??,
             };
-            Some(pac)
-        } else {
-            None
-        };
+            scripts.push(pac);
+        }
         self.eval
-            .set_pac_script(pac)
+            .set_pac_scripts(scripts)
             .await
             .map_err(std::io::Error::other)
+    }
+
+    pub async fn load_pac_file(&self, uri: &Option<PathOrUri>) -> std::io::Result<()> {
+        self.load_pac_files(uri.as_slice()).await
     }
 
     #[instrument(skip(self))]

--- a/proxydetoxlib/src/context/builder.rs
+++ b/proxydetoxlib/src/context/builder.rs
@@ -8,7 +8,7 @@ use tokio::sync::broadcast;
 
 #[derive(Debug, Default)]
 pub struct Builder {
-    pac_file: Option<PathOrUri>,
+    pac_files: Vec<PathOrUri>,
     pac_script: Option<String>,
     auth: Option<AuthenticatorFactory>,
     proxytunnel: bool,
@@ -24,7 +24,13 @@ impl Builder {
     /// PAC script URI to be loaded and used for evaluation
     /// If `None`, FindProxy will evaluate to DIRECT
     pub fn pac_file(mut self, uri: Option<PathOrUri>) -> Self {
-        self.pac_file = uri;
+        self.pac_files = uri.into_iter().collect();
+        self
+    }
+
+    /// PAC script URIs to be loaded and used for evaluation, in order.
+    pub fn pac_files(mut self, uris: Vec<PathOrUri>) -> Self {
+        self.pac_files = uris;
         self
     }
 
@@ -115,12 +121,13 @@ impl Builder {
         };
         let context = Arc::new(context);
 
-        if self.pac_file.is_some() {
+        if !self.pac_files.is_empty() {
             tokio::spawn({
                 let context = context.clone();
+                let pac_files = self.pac_files;
                 async move {
-                    if let Err(cause) = context.load_pac_file(&self.pac_file).await {
-                        tracing::error!(%cause, pac_file = ?&self.pac_file, "failed to load PAC from URI");
+                    if let Err(cause) = context.load_pac_files(&pac_files).await {
+                        tracing::error!(%cause, pac_files = ?pac_files, "failed to load PAC files");
                     }
                 }
             });


### PR DESCRIPTION
## Summary

- allow repeating `--pac-file` for ordered PAC sources
- support local PAC files, including symlinks, alongside HTTP/HTTPS URLs
- evaluate PAC files independently and fall through on `DIRECT`
- reload all configured PAC files together

## Testing

- `cargo test -p paclib -p proxydetox -p proxydetoxlib`